### PR TITLE
Add aesthetic + feature improvements across 6 phases

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,26 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>3D Weather Clock</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;700&display=swap" rel="stylesheet">
     <style>
+        /* ── CSS Custom Properties (updated per-frame by updatePanelTheme) ── */
+        :root {
+            --panel-bg: rgba(0, 0, 0, 0.6);
+            --panel-border: rgba(255, 255, 255, 0.1);
+            --header-color: #88d8f9;
+            --trend-glow: transparent;
+        }
+
         body {
             margin: 0;
             padding: 0;
             overflow: hidden;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: #000; /* Let Three.js handle the background */
+            font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #000;
         }
+
         #canvas-container {
             width: 100vw;
             height: 100vh;
@@ -28,15 +40,16 @@
             width: 100%;
             height: 100%;
             z-index: 2;
-            pointer-events: none; /* Allow clicking through to 3D scene */
+            pointer-events: none;
             display: grid;
             grid-template-columns: 300px 1fr 300px;
             padding: 20px;
             box-sizing: border-box;
         }
 
+        /* ── Panels ── */
         .panel {
-            background: rgba(0, 0, 0, 0.6);
+            background: var(--panel-bg);
             backdrop-filter: blur(10px);
             border-radius: 15px;
             padding: 20px;
@@ -44,14 +57,14 @@
             pointer-events: auto;
             display: flex;
             flex-direction: column;
-            border: 1px solid rgba(255, 255, 255, 0.1);
+            border: 1px solid var(--panel-border);
+            box-shadow: 0 0 30px var(--trend-glow);
             height: fit-content;
             margin-top: 15vh;
-            transition: all 0.3s ease;
+            transition: background 0.8s ease, border-color 0.8s ease, box-shadow 0.6s ease;
         }
 
         .panel:hover {
-            background: rgba(0, 0, 0, 0.75);
             border-color: rgba(255, 255, 255, 0.3);
         }
 
@@ -59,15 +72,17 @@
             background: none;
             border: none;
             backdrop-filter: none;
+            box-shadow: none;
             align-items: center;
             margin-top: 50px;
-            pointer-events: none; /* Let clicks pass through, but re-enable for children */
+            pointer-events: none;
         }
 
         #panel-center > * {
             pointer-events: auto;
         }
 
+        /* ── Typography ── */
         .time-display {
             font-size: 72px;
             font-weight: 200;
@@ -86,8 +101,39 @@
             gap: 10px;
         }
 
+        h3 {
+            margin: 0 0 15px 0;
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: var(--header-color);
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+            padding-bottom: 10px;
+            transition: color 0.8s ease;
+        }
+
+        .stat-row {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 10px;
+            font-size: 14px;
+        }
+
+        .stat-value {
+            font-weight: 600;
+            color: #eee;
+        }
+
+        .description {
+            font-size: 19px;
+            margin-bottom: 16px;
+            font-weight: 500;
+            min-height: 28px;
+        }
+
+        /* ── Retry button ── */
         .retry-btn {
-            background: rgba(255, 255, 255, 0.2);
+            background: rgba(255,255,255,0.2);
             border: none;
             border-radius: 50%;
             width: 24px;
@@ -100,33 +146,58 @@
             font-size: 14px;
             transition: background 0.2s;
         }
+        .retry-btn:hover { background: rgba(255,255,255,0.4); }
 
-        .retry-btn:hover {
-            background: rgba(255, 255, 255, 0.4);
-        }
-
-        .unit-toggle {
+        /* ── Unit toggle switch ── */
+        .unit-switch {
+            display: flex;
+            align-items: center;
+            gap: 8px;
             cursor: pointer;
-            padding: 5px 10px;
-            background: rgba(255,255,255,0.1);
-            border-radius: 15px;
+            margin-top: 8px;
             font-size: 14px;
-            margin-top: 5px;
-            transition: background 0.2s;
-            border: 1px solid rgba(255,255,255,0.2);
+            user-select: none;
+            color: white;
         }
-
-        .unit-toggle:hover {
-            background: rgba(255,255,255,0.2);
+        .unit-sw-label {
+            opacity: 0.5;
+            font-weight: 500;
+            transition: opacity 0.2s;
+            min-width: 18px;
+            text-align: center;
         }
+        .unit-switch[data-unit='metric']   .unit-sw-label:first-child { opacity: 1; font-weight: 700; }
+        .unit-switch[data-unit='imperial'] .unit-sw-label:last-child  { opacity: 1; font-weight: 700; }
+        .unit-switch-track {
+            width: 40px;
+            height: 22px;
+            background: rgba(255,255,255,0.15);
+            border-radius: 11px;
+            position: relative;
+            border: 1px solid rgba(255,255,255,0.25);
+            transition: background 0.25s;
+        }
+        .unit-switch-thumb {
+            position: absolute;
+            top: 3px;
+            left: 3px;
+            width: 14px;
+            height: 14px;
+            background: white;
+            border-radius: 50%;
+            transition: transform 0.25s;
+            box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+        }
+        .unit-switch[data-unit='imperial'] .unit-switch-thumb { transform: translateX(18px); }
+        .unit-switch[data-unit='imperial'] .unit-switch-track { background: rgba(100,200,255,0.4); }
 
+        /* ── Search ── */
         .search-container {
             margin-top: 10px;
             display: flex;
             gap: 5px;
             height: 30px;
         }
-
         .search-input {
             background: rgba(0,0,0,0.5);
             border: 1px solid rgba(255,255,255,0.3);
@@ -135,8 +206,8 @@
             color: white;
             outline: none;
             width: 150px;
+            font-family: inherit;
         }
-
         .search-btn {
             background: rgba(255,255,255,0.2);
             border: none;
@@ -146,66 +217,98 @@
             cursor: pointer;
             font-weight: bold;
         }
+        .search-btn:hover { background: rgba(255,255,255,0.3); }
 
-        .search-btn:hover {
-            background: rgba(255,255,255,0.3);
+        /* ── Center panel large displays ── */
+        .current-temp-large {
+            font-size: 56px;
+            font-weight: 700;
+            text-shadow: 0 2px 10px rgba(0,0,0,0.8);
+            margin: 8px 0 2px;
+            line-height: 1;
         }
-
         .current-weather-large {
-            font-size: 24px;
-            margin-top: 5px;
+            font-size: 22px;
+            margin-top: 4px;
             text-align: center;
             text-shadow: 0 2px 5px rgba(0,0,0,0.8);
             opacity: 0.9;
         }
 
-        .current-temp-large {
-            font-size: 56px;
-            font-weight: bold;
-            text-shadow: 0 2px 10px rgba(0,0,0,0.8);
-            margin: 10px 0;
-        }
-
-        h3 {
-            margin: 0 0 15px 0;
-            font-size: 14px;
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            color: #88d8f9;
-            border-bottom: 1px solid rgba(255,255,255,0.1);
-            padding-bottom: 10px;
-        }
-
-        .stat-row {
+        /* ── Feels-like + UV badge ── */
+        .feels-row {
             display: flex;
-            justify-content: space-between;
-            margin-bottom: 12px;
-            font-size: 15px;
+            align-items: center;
+            gap: 10px;
+            font-size: 13px;
+            opacity: 0.8;
+            margin-bottom: 6px;
+        }
+        .uv-badge {
+            background: rgba(255, 200, 50, 0.2);
+            border: 1px solid rgba(255, 200, 50, 0.4);
+            border-radius: 8px;
+            padding: 1px 7px;
+            font-size: 11px;
+            color: #ffd060;
+            font-weight: 600;
         }
 
-        .stat-value {
-            font-weight: bold;
-            color: #eee;
+        /* ── Sparkline canvas ── */
+        #sparkline {
+            display: block;
+            margin: 4px auto 0;
+            width: 100%;
+            max-width: 280px;
+            height: 60px;
+            opacity: 0.85;
         }
 
-        .description {
-            font-size: 20px;
-            margin-bottom: 20px;
-            font-weight: 500;
-            min-height: 30px;
-        }
-
+        /* ── Center stats pill ── */
         .center-stats {
-            margin-top: 20px;
+            margin-top: 18px;
             background: rgba(0,0,0,0.5);
-            padding: 15px 25px;
-            border-radius: 30px;
+            padding: 12px 20px;
+            border-radius: 20px;
             backdrop-filter: blur(5px);
             display: flex;
-            gap: 20px;
+            flex-wrap: wrap;
+            gap: 10px 18px;
             border: 1px solid rgba(255,255,255,0.1);
+            justify-content: center;
+            max-width: 320px;
         }
+        .cs-item {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            font-size: 14px;
+            white-space: nowrap;
+        }
+        .wind-svg {
+            width: 18px;
+            height: 18px;
+            vertical-align: middle;
+            flex-shrink: 0;
+        }
+        /* SVG wind arrow transform — JS sets inline transform on the group */
 
+        /* ── Time warp button ── */
+        #time-warp-btn {
+            background: rgba(100, 255, 100, 0.4);
+            border: 1px solid rgba(255,255,255,0.5);
+            border-radius: 50%;
+            width: 50px;
+            height: 50px;
+            color: white;
+            cursor: pointer;
+            font-size: 24px;
+            transition: all 0.2s;
+            box-shadow: 0 0 10px rgba(0,0,0,0.3);
+        }
+        #time-warp-btn:hover { transform: scale(1.1); }
+
+        /* ── Advanced panel ── */
         #panel-advanced {
             position: absolute;
             bottom: 40px;
@@ -219,23 +322,9 @@
             margin-top: 0;
             background: rgba(0, 0, 0, 0.75);
         }
-
-        .adv-section {
-            text-align: center;
-        }
-
-        .adv-val-big {
-            font-size: 24px;
-            font-weight: bold;
-            color: #fff;
-            margin: 5px 0;
-        }
-
-        .adv-sub {
-            font-size: 13px;
-            opacity: 0.8;
-        }
-
+        .adv-section { text-align: center; }
+        .adv-val-big { font-size: 24px; font-weight: bold; color: #fff; margin: 5px 0; }
+        .adv-sub { font-size: 13px; opacity: 0.8; }
         .regional-list {
             font-size: 13px;
             text-align: left;
@@ -244,24 +333,17 @@
             gap: 5px 15px;
         }
 
-        #time-warp-btn {
-            background: rgba(100, 255, 100, 0.4);
-            border: 1px solid rgba(255,255,255,0.5);
-            border-radius: 50%;
-            width: 50px;
-            height: 50px;
-            color: white;
-            cursor: pointer;
-            font-size: 24px;
-            transition: all 0.2s;
-            box-shadow: 0 0 10px rgba(0,0,0,0.3);
+        /* ── DEV hint ── */
+        #dev-hint {
+            position: fixed;
+            bottom: 8px;
+            right: 8px;
+            font-size: 10px;
+            color: rgba(255,255,255,0.25);
+            pointer-events: none;
+            z-index: 10;
+            font-family: monospace;
         }
-
-        #time-warp-btn:hover {
-            transform: scale(1.1);
-            background: rgba(100, 255, 100, 0.6);
-        }
-
     </style>
 </head>
 <body>
@@ -270,19 +352,31 @@
     <div id="ui-layer">
         <!-- LEFT: Previous Data -->
         <div id="panel-left" class="panel">
-            <h3>⏮️ Previous <span id="past-time-display" style="font-size: 0.8em; opacity: 0.8;"></span></h3>
+            <h3>⏮️ Previous <span id="past-time-display" style="font-size:0.8em;opacity:0.8;"></span></h3>
             <div id="past-description" class="description">--</div>
             <div class="stat-row">
                 <span>Temp</span>
                 <span id="past-temp" class="stat-value">--°</span>
             </div>
             <div class="stat-row">
+                <span>Feels Like</span>
+                <span id="past-feels-like" class="stat-value">--°</span>
+            </div>
+            <div class="stat-row">
                 <span>Wind</span>
                 <span id="past-wind" class="stat-value">-- km/h</span>
             </div>
-             <div class="stat-row">
+            <div class="stat-row">
+                <span>Humidity</span>
+                <span id="past-humidity" class="stat-value">--%</span>
+            </div>
+            <div class="stat-row">
                 <span>Cloud Cover</span>
                 <span id="past-cloud" class="stat-value">--%</span>
+            </div>
+            <div class="stat-row">
+                <span>Precip. Prob.</span>
+                <span id="past-precip-prob" class="stat-value">--%</span>
             </div>
         </div>
 
@@ -294,41 +388,81 @@
             </div>
 
             <div class="search-container">
-                <input type="text" id="location-search" class="search-input" placeholder="City name..." />
+                <input type="text" id="location-search" class="search-input" placeholder="City name…" />
                 <button id="search-btn" class="search-btn">Go</button>
             </div>
 
-            <div style="display: flex; align-items: center; gap: 10px; margin-top: 10px;">
+            <div style="display:flex;align-items:center;gap:10px;margin-top:10px;">
                 <div id="time-display" class="time-display">--:--</div>
                 <button id="time-warp-btn" title="Fast Forward (24h in 60s)">⏩</button>
             </div>
-            <div id="date-display" style="font-size: 24px; opacity: 0.8; margin-top: -10px; margin-bottom: 10px; font-weight: 300;">--</div>
+            <div id="date-display" style="font-size:22px;opacity:0.8;margin-top:-8px;margin-bottom:8px;font-weight:300;">--</div>
 
             <div id="current-temp" class="current-temp-large">--°</div>
-            <button id="unit-toggle" class="unit-toggle">Switch to °C</button>
-            <div id="current-description" class="current-weather-large">Loading...</div>
 
+            <!-- Feels-like + UV badge -->
+            <div class="feels-row">
+                <span>Feels like <span id="current-feels-like" class="stat-value">--°</span></span>
+                <span id="current-uv" class="uv-badge">UV --</span>
+            </div>
+
+            <!-- Unit toggle switch -->
+            <div id="unit-toggle" class="unit-switch" data-unit="imperial" role="button" tabindex="0" aria-label="Toggle temperature unit">
+                <span class="unit-sw-label">°C</span>
+                <span class="unit-switch-track"><span class="unit-switch-thumb"></span></span>
+                <span class="unit-sw-label">°F</span>
+            </div>
+
+            <div id="current-description" class="current-weather-large">Loading…</div>
+
+            <!-- 12-hour sparkline -->
+            <canvas id="sparkline" width="280" height="60"></canvas>
+
+            <!-- Stats pill -->
             <div class="center-stats">
-                <span>💨 <span id="current-wind" class="stat-value">-- km/h</span></span>
-                <span>🌙 <span id="moon-phase" class="stat-value">--</span></span>
+                <span class="cs-item">
+                    <!-- Wind direction compass SVG -->
+                    <svg id="wind-compass" class="wind-svg" viewBox="0 0 20 20" aria-hidden="true">
+                        <circle cx="10" cy="10" r="8" fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="1.5"/>
+                        <g id="wind-arrow" style="transform-origin:10px 10px;transform:rotate(0deg);transition:transform 0.5s ease;">
+                            <polygon points="10,2 8,9 10,7 12,9" fill="white"/>
+                        </g>
+                    </svg>
+                    <span id="current-wind" class="stat-value">--</span> km/h
+                </span>
+                <span class="cs-item">🌙 <span id="moon-phase" class="stat-value">--</span></span>
+                <span class="cs-item">🌅 <span id="sunrise-time" class="stat-value">--:--</span></span>
+                <span class="cs-item">🌇 <span id="sunset-time" class="stat-value">--:--</span></span>
             </div>
         </div>
 
         <!-- RIGHT: Forecast Data -->
         <div id="panel-right" class="panel">
-            <h3>⏭️ Forecast <span id="forecast-time-display" style="font-size: 0.8em; opacity: 0.8;"></span></h3>
+            <h3>⏭️ Forecast <span id="forecast-time-display" style="font-size:0.8em;opacity:0.8;"></span></h3>
             <div id="forecast-description" class="description">--</div>
-             <div class="stat-row">
+            <div class="stat-row">
                 <span>Temp</span>
                 <span id="forecast-temp" class="stat-value">--°</span>
+            </div>
+            <div class="stat-row">
+                <span>Feels Like</span>
+                <span id="forecast-feels-like" class="stat-value">--°</span>
             </div>
             <div class="stat-row">
                 <span>Wind</span>
                 <span id="forecast-wind" class="stat-value">-- km/h</span>
             </div>
-             <div class="stat-row">
+            <div class="stat-row">
+                <span>Humidity</span>
+                <span id="forecast-humidity" class="stat-value">--%</span>
+            </div>
+            <div class="stat-row">
                 <span>Cloud Cover</span>
                 <span id="forecast-cloud" class="stat-value">--%</span>
+            </div>
+            <div class="stat-row">
+                <span>Precip. Prob.</span>
+                <span id="forecast-precip-prob" class="stat-value">--%</span>
             </div>
         </div>
 
@@ -339,21 +473,20 @@
                 <div id="history-temp" class="adv-val-big">--°</div>
                 <div id="history-desc" class="adv-sub">--</div>
             </div>
-
             <div class="adv-section">
                 <h3>🎯 Forecast Accuracy</h3>
                 <div id="accuracy-delta" class="adv-val-big">--</div>
                 <div id="accuracy-score" class="adv-sub">Score: --%</div>
             </div>
-
             <div class="adv-section">
                 <h3>📍 Nearby Regions</h3>
-                <div id="regional-list" class="regional-list">
-                    <!-- Populated by JS -->
-                </div>
+                <div id="regional-list" class="regional-list"></div>
             </div>
         </div>
     </div>
+
+    <!-- DEV hint -->
+    <div id="dev-hint">` — toggle stats</div>
 
     <script type="importmap">
         {

--- a/src/animation.js
+++ b/src/animation.js
@@ -2,13 +2,20 @@
 import * as THREE from 'three';
 import { updateMoonVisuals } from './moonPhase.js';
 import { updateWeatherLighting } from './weatherLighting.js';
-import { getWeatherAtTime, getActiveWeatherData } from './weather-simulation.js';
-import { updateTimeDisplay, updateWeatherDisplay } from './ui.js';
+import { getActiveWeatherData } from './weather-simulation.js';
+import {
+    updateTimeDisplay,
+    updateWeatherDisplay,
+    updateWindCompass,
+    updatePanelTheme,
+    drawSparkline
+} from './ui.js';
 
 const ANIMATION_CONFIG = {
     realTimeScale: 1.0,
-    warpTimeScale: 1440.0, // 24h in 60s
-    weatherUpdateThrottle: 0.1, // 10% chance per frame when warping
+    warpTimeScale: 1440.0,        // 24 h in 60 s
+    weatherUpdateThrottle: 0.1,   // 10 % chance per frame during time warp
+    themeUpdateInterval: 500,     // ms between panel-theme updates
 };
 
 export class AnimationController {
@@ -17,13 +24,13 @@ export class AnimationController {
         this.services = services;
         this.scene3d = scene3d;
         this.isRunning = false;
+
+        // Throttle trackers
+        this._lastThemeMs = 0;
+        this._lastSparklineHour = -1;
     }
 
-    /**
-     * Start the animation loop
-     * @param {THREE.Clock} clock - Three.js clock for delta time
-     * @param {Stats} stats - Performance stats object
-     */
+    /** Start the rAF loop */
     start(clock, stats) {
         if (this.isRunning) return;
         this.isRunning = true;
@@ -31,46 +38,40 @@ export class AnimationController {
         const animate = () => {
             requestAnimationFrame(animate);
             stats.update();
-            this.update(clock.getDelta(), stats);
+            this.update(clock.getDelta());
         };
 
         animate();
     }
 
-    /**
-     * Main update loop
-     * @param {number} delta - Delta time in seconds
-     * @param {Stats} stats - Performance stats object
-     */
-    update(delta, stats) {
+    /** Per-frame update */
+    update(delta) {
         const { state, services, scene3d } = this;
         const { weatherService, astronomyService } = services;
         const {
-            scene,
-            camera,
-            composer,
-            sky,
-            sundial,
-            moonGroup,
-            weatherEffects,
-            sunLight,
-            moonLight,
-            ambientLight
+            scene, composer, sky,
+            sundial, moonGroup, weatherEffects,
+            sunLight, moonLight, ambientLight,
+            controls
         } = scene3d;
 
-        // Update simulation time
-        const timeScale = state.isTimeWarping ? ANIMATION_CONFIG.warpTimeScale : ANIMATION_CONFIG.realTimeScale;
+        // ── Advance simulation time ──
+        const timeScale = state.isTimeWarping
+            ? ANIMATION_CONFIG.warpTimeScale
+            : ANIMATION_CONFIG.realTimeScale;
         state.simulationTime = new Date(state.simulationTime.getTime() + delta * 1000 * timeScale);
 
-        // Update sundial
+        // ── Orbit controls damping ──
+        if (controls) controls.update();
+
+        // ── Sundial ──
         sundial.update(state.simulationTime);
 
-        // Update astronomy
+        // ── Astronomy ──
         const lat = weatherService.latitude;
         const lon = weatherService.longitude;
         const astroData = astronomyService.update(state.simulationTime, lat, lon, 20);
 
-        // Update light positions
         sunLight.position.copy(astroData.sunPosition);
         moonGroup.position.copy(astroData.moonPosition);
         moonGroup.lookAt(0, 0, 0);
@@ -80,36 +81,29 @@ export class AnimationController {
             updateMoonVisuals(moonGroup, astroData.sunPosition);
         }
 
-        // Update UI time display
+        // ── Time display ──
         updateTimeDisplay(state.simulationTime, state.isTimeWarping);
 
-        // Get active weather data
+        // ── Weather data for simulation time ──
         const activeWeatherData = getActiveWeatherData(state.simulationTime, state.weatherData);
 
         if (activeWeatherData) {
-            // Update lighting
-            if (astroData && astroData.sunPosition && astroData.sunPosition.lengthSq() > 0) {
-                updateWeatherLighting(
-                    scene,
-                    sunLight,
-                    moonLight,
-                    ambientLight,
-                    sky,
-                    {
-                        current: activeWeatherData.current,
-                        past: activeWeatherData.past,
-                        forecast: activeWeatherData.forecast
-                    },
-                    astroData
-                );
+            // Lighting
+            if (astroData.sunPosition.lengthSq() > 0) {
+                updateWeatherLighting(scene, sunLight, moonLight, ambientLight, sky, {
+                    current: activeWeatherData.current,
+                    past: activeWeatherData.past,
+                    forecast: activeWeatherData.forecast
+                }, astroData);
             }
 
-            // Update weather effects
+            // Weather effects
+            const empty = { weatherCode: 0, windSpeed: 0, windDirection: 0 };
             weatherEffects.update(
-                activeWeatherData.past || { weatherCode: 0, windSpeed: 0, windDirection: 0 },
-                activeWeatherData.current || { weatherCode: 0, windSpeed: 0, windDirection: 0 },
-                activeWeatherData.forecast || { weatherCode: 0, windSpeed: 0, windDirection: 0 },
-                delta, // Real delta for smooth animation
+                activeWeatherData.past     || empty,
+                activeWeatherData.current  || empty,
+                activeWeatherData.forecast || empty,
+                delta,
                 ambientLight.color,
                 sunLight.position,
                 moonLight.position,
@@ -117,43 +111,67 @@ export class AnimationController {
                 moonLight.color
             );
 
+            // Wind compass (per-frame, lightweight DOM update)
+            if (activeWeatherData.current?.windDirection != null) {
+                updateWindCompass(activeWeatherData.current.windDirection);
+            }
+
             // Throttled weather display update during time warp
             if (state.isTimeWarping && Math.random() < ANIMATION_CONFIG.weatherUpdateThrottle) {
-                const displayData = {
+                updateWeatherDisplay({
                     ...state.weatherData,
                     current: activeWeatherData.current,
                     past: activeWeatherData.past,
                     forecast: activeWeatherData.forecast
-                };
-                updateWeatherDisplay(displayData, weatherService);
+                }, weatherService);
             }
+
+            // ── Panel theme (throttled: ~2 Hz) ──
+            const nowMs = performance.now();
+            if (nowMs - this._lastThemeMs > ANIMATION_CONFIG.themeUpdateInterval) {
+                this._lastThemeMs = nowMs;
+
+                // dayFactor: normalised sin of sun altitude (-1 night … +1 noon)
+                const dayFactor = astroData.sunPosition.y / 20;
+                const weatherSeverity = activeWeatherData.current?.severity ?? 0;
+
+                // tempTrend: how much warmer/cooler today is vs the same date last year
+                // clamped to ±1 over a 10 °C swing
+                const histTemp = state.weatherData?.historicalYearAgo?.temp;
+                const currTemp = activeWeatherData.current?.temp;
+                const tempTrend = (histTemp != null && currTemp != null)
+                    ? Math.max(-1, Math.min(1, (currTemp - histTemp) / 10))
+                    : 0;
+
+                updatePanelTheme(dayFactor, weatherSeverity, tempTrend);
+            }
+
+            // ── Sparkline — redraw when the simulation hour rolls over ──
+            const simHour = Math.floor(state.simulationTime.getTime() / 3_600_000);
+            if (simHour !== this._lastSparklineHour && state.weatherData) {
+                this._lastSparklineHour = simHour;
+                drawSparkline(state.simulationTime, state.weatherData, weatherService);
+            }
+
         } else {
-            // No weather data, render empty effects
-            weatherEffects.update(
-                { weatherCode: 0, windSpeed: 0, windDirection: 0 },
-                { weatherCode: 0, windSpeed: 0, windDirection: 0 },
-                { weatherCode: 0, windSpeed: 0, windDirection: 0 },
-                delta,
-                ambientLight.color
-            );
+            // No data — still run effects at idle
+            const empty = { weatherCode: 0, windSpeed: 0, windDirection: 0 };
+            weatherEffects.update(empty, empty, empty, delta, ambientLight.color);
         }
 
-        // Handle lightning flashes
-        if (weatherEffects.getLightningFlash && weatherEffects.getLightningFlash() > 0) {
+        // ── Lightning flash ──
+        if (weatherEffects.getLightningFlash?.() > 0) {
             const flash = weatherEffects.getLightningFlash();
             ambientLight.intensity += flash;
 
             const flashColor = new THREE.Color(0xaaddff);
-            const lerpFactor = Math.min(1.0, flash * 0.8);
-            ambientLight.color.lerp(flashColor, lerpFactor);
+            ambientLight.color.lerp(flashColor, Math.min(1.0, flash * 0.8));
 
-            // Sync fog color with lightning
             if (scene.fog) {
                 scene.fog.color.copy(ambientLight.color).multiplyScalar(0.8);
             }
         }
 
-        // Render
         composer.render();
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,25 +1,24 @@
 import * as THREE from 'three';
 import Stats from 'three/addons/libs/stats.module.js';
 
-// Import modular components
 import { setupRendering } from './rendering.js';
 import { setupLights } from './lights.js';
 import { setupSky, setupSundial, setupMoon, setupWeatherEffects, addToScene } from './scene-objects.js';
 import { WeatherService } from './weather.js';
 import { AstronomyService } from './astronomy.js';
 import {
-    formatTime12,
     updateTimeDisplay,
     updateWeatherDisplay,
     updateUnitButton,
     setupEventListeners,
     updateTimeWarpButton,
-    setSearchLoading
+    setSearchLoading,
+    drawSparkline
 } from './ui.js';
 import { AnimationController } from './animation.js';
 import { setupDebugAPI } from './debug.js';
 
-// ============= Application State =============
+// ── Application State ────────────────────────────────────────────────────────
 const state = {
     weatherData: null,
     simulationTime: new Date(),
@@ -27,55 +26,54 @@ const state = {
     isDebugMode: false
 };
 
-const WEATHER_REFRESH_INTERVAL = 10 * 60 * 1000; // 10 minutes
+const WEATHER_REFRESH_INTERVAL = 10 * 60 * 1000; // 10 min
 
-// ============= Initialize 3D Rendering =============
-const { scene, camera, renderer, composer, clock } = setupRendering();
+// ── Rendering ────────────────────────────────────────────────────────────────
+const { scene, camera, renderer, composer, clock, controls } = setupRendering();
 
-// ============= Setup Scene Lighting =============
+// ── Lighting ─────────────────────────────────────────────────────────────────
 const { ambientLight, sunLight, moonLight } = setupLights(scene);
 
-// ============= Setup Scene Objects =============
+// ── Scene Objects ────────────────────────────────────────────────────────────
 const sky = setupSky();
 const sundial = setupSundial();
-const { moonGroup, moonPhaseData } = setupMoon();
+const { moonGroup } = setupMoon();
 const weatherEffects = setupWeatherEffects(scene, sundial, camera);
-
-// Add objects to scene
 addToScene(scene, { sky, sundial, moonGroup });
 
-// ============= Setup Services =============
+// ── Services ─────────────────────────────────────────────────────────────────
 const weatherService = new WeatherService();
 const astronomyService = new AstronomyService();
 
-// ============= Setup Performance Monitoring =============
+// ── Stats (hidden by default; backtick ` toggles) ────────────────────────────
 const stats = new Stats();
+stats.dom.style.display = 'none';
 document.body.appendChild(stats.dom);
 
-// ============= Setup Animation Loop =============
-const animationController = new AnimationController(state, { weatherService, astronomyService }, {
-    scene,
-    camera,
-    composer,
-    sky,
-    sundial,
-    moonGroup,
-    weatherEffects,
-    sunLight,
-    moonLight,
-    ambientLight
+window.addEventListener('keydown', (e) => {
+    if (e.key === '`') {
+        stats.dom.style.display = stats.dom.style.display === 'none' ? 'block' : 'none';
+    }
 });
 
-// ============= UI Event Handlers =============
+// ── Animation loop ────────────────────────────────────────────────────────────
+const animationController = new AnimationController(
+    state,
+    { weatherService, astronomyService },
+    { scene, camera, composer, sky, sundial, moonGroup, weatherEffects, sunLight, moonLight, ambientLight, controls }
+);
+
+// ── UI Event Callbacks ────────────────────────────────────────────────────────
 function setupUICallbacks() {
     return {
         onRetryLocation: async () => {
-            document.getElementById('location').textContent = 'Retrying...';
+            document.getElementById('location').textContent = 'Retrying…';
             try {
                 await weatherService.getLocation();
                 const data = await weatherService.fetchWeather();
                 state.weatherData = data;
                 updateWeatherDisplay(data, weatherService);
+                drawSparkline(state.simulationTime, data, weatherService);
             } catch (error) {
                 console.error('Location retry failed:', error);
                 document.getElementById('location').textContent = 'Location unavailable';
@@ -87,29 +85,25 @@ function setupUICallbacks() {
             updateUnitButton(weatherService);
             if (state.weatherData) {
                 updateWeatherDisplay(state.weatherData, weatherService);
+                drawSparkline(state.simulationTime, state.weatherData, weatherService);
             }
         },
 
         onSearch: async (query) => {
             if (!query) return;
-
             setSearchLoading(true);
             try {
                 const results = await weatherService.searchLocation(query);
                 if (results && results.length > 0) {
                     const best = results[0];
-                    weatherService.setManualLocation(
-                        best.lat,
-                        best.lon,
-                        best.display_name.split(',')[0]
-                    );
+                    weatherService.setManualLocation(best.lat, best.lon, best.display_name.split(',')[0]);
 
-                    document.getElementById('location').textContent = 'Updating...';
+                    document.getElementById('location').textContent = 'Updating…';
                     const data = await weatherService.fetchWeather();
                     state.weatherData = data;
                     updateWeatherDisplay(data, weatherService);
+                    drawSparkline(state.simulationTime, data, weatherService);
 
-                    // Clear search input
                     const searchInput = document.getElementById('location-search');
                     if (searchInput) searchInput.value = '';
                 } else {
@@ -130,16 +124,17 @@ function setupUICallbacks() {
     };
 }
 
-// ============= Fetch and Display Weather =============
+// ── Weather fetch ─────────────────────────────────────────────────────────────
 async function fetchAndDisplayWeather() {
     if (state.isDebugMode) return;
 
-    document.getElementById('location').textContent = 'Loading...';
+    document.getElementById('location').textContent = 'Loading…';
     try {
         const data = await weatherService.initialize();
         if (state.isDebugMode) return;
         state.weatherData = data;
         updateWeatherDisplay(data, weatherService);
+        drawSparkline(state.simulationTime, data, weatherService);
     } catch (error) {
         console.error('Weather initialization failed:', error);
         document.getElementById('location').textContent = 'Weather data unavailable';
@@ -147,33 +142,22 @@ async function fetchAndDisplayWeather() {
     }
 }
 
-// ============= Initialize Application =============
+// ── Init ──────────────────────────────────────────────────────────────────────
 async function init() {
-    // Update initial UI state
     updateTimeDisplay(state.simulationTime, state.isTimeWarping);
     updateUnitButton(weatherService);
 
-    // Setup event listeners
     const callbacks = setupUICallbacks();
     setupEventListeners(callbacks);
 
-    // Setup debug API
     setupDebugAPI(state, { weatherService, astronomyService }, {
-        scene,
-        sky,
-        weatherEffects,
-        sunLight,
-        moonLight,
-        ambientLight
+        scene, sky, weatherEffects, sunLight, moonLight, ambientLight
     });
 
-    // Start animation loop
     animationController.start(clock, stats);
 
-    // Fetch initial weather
     await fetchAndDisplayWeather();
 
-    // Setup weather refresh interval
     setInterval(async () => {
         if (state.isDebugMode) return;
         try {
@@ -181,11 +165,11 @@ async function init() {
             if (state.isDebugMode) return;
             state.weatherData = data;
             updateWeatherDisplay(data, weatherService);
+            drawSparkline(state.simulationTime, data, weatherService);
         } catch (error) {
             console.error('Weather update failed:', error);
         }
     }, WEATHER_REFRESH_INTERVAL);
 }
 
-// ============= Start Application =============
 init();

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -1,8 +1,9 @@
-// Rendering setup: scene, renderer, camera, post-processing
+// Rendering setup: scene, renderer, camera, post-processing, orbit controls
 import * as THREE from 'three';
 import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 // Configuration constants
 const RENDERING_CONFIG = {
@@ -80,7 +81,16 @@ export function setupRendering() {
     };
     window.addEventListener('resize', handleResize);
 
-    return { scene, camera, renderer, composer, clock: new THREE.Clock() };
+    // Orbit controls — lets the user drag to explore the scene
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 0, 0);
+    controls.minDistance = 4;
+    controls.maxDistance = 30;
+    controls.maxPolarAngle = Math.PI / 2; // Don't go below ground
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.05;
+
+    return { scene, camera, renderer, composer, clock: new THREE.Clock(), controls };
 }
 
 export { RENDERING_CONFIG };

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,6 @@
-// UI management: DOM updates and event listeners
+// UI management: DOM updates, event listeners, animations
 import { calculateMoonPhase } from './moonPhase.js';
+import { getWeatherAtTime } from './weather-simulation.js';
 
 const UI_CONFIG = {
     timeWarpColorActive: 'rgba(255, 100, 100, 0.8)',
@@ -12,250 +13,372 @@ const UI_CONFIG = {
     timeNormalGlow: '0 0 5px #000000',
 };
 
-/**
- * Format time in 12-hour format
- * @param {Date} date - Date to format
- * @returns {string} Formatted time string (e.g., "3:45 PM")
- */
+// ── countTo: rAF-driven number animation (800 ms, ease-out cubic) ──────────
+const _countState = new Map();
+
+export function countTo(el, newVal, suffix = '') {
+    if (!el) return;
+    const currentVal = parseFloat(el.dataset.animVal ?? el.textContent) || 0;
+    if (Math.abs(currentVal - newVal) < 0.5) {
+        el.textContent = newVal + suffix;
+        el.dataset.animVal = String(newVal);
+        return;
+    }
+
+    if (_countState.has(el)) cancelAnimationFrame(_countState.get(el));
+
+    const duration = 800;
+    const startTime = performance.now();
+    const startVal = currentVal;
+
+    const step = (now) => {
+        const t = Math.min((now - startTime) / duration, 1);
+        const eased = 1 - Math.pow(1 - t, 3);
+        const val = Math.round(startVal + (newVal - startVal) * eased);
+        el.textContent = val + suffix;
+        el.dataset.animVal = String(val);
+        if (t < 1) {
+            _countState.set(el, requestAnimationFrame(step));
+        } else {
+            el.textContent = newVal + suffix;
+            el.dataset.animVal = String(newVal);
+            _countState.delete(el);
+        }
+    };
+    _countState.set(el, requestAnimationFrame(step));
+}
+
+// ── formatTime12 ─────────────────────────────────────────────────────────────
 export function formatTime12(date) {
     let hours = date.getHours();
     const minutes = date.getMinutes().toString().padStart(2, '0');
     const ampm = hours >= 12 ? 'PM' : 'AM';
-    hours = hours % 12;
-    hours = hours ? hours : 12;
+    hours = hours % 12 || 12;
     return `${hours}:${minutes} ${ampm}`;
 }
 
-/**
- * Update time and date displays
- * @param {Date} simulationTime - Current simulation time
- * @param {boolean} isTimeWarping - Whether time warp is active
- */
+// ── updateTimeDisplay ────────────────────────────────────────────────────────
 export function updateTimeDisplay(simulationTime, isTimeWarping) {
     const timeDisplay = document.getElementById('time-display');
     if (!timeDisplay) return;
 
     timeDisplay.textContent = formatTime12(simulationTime);
 
-    // Update date display
     const dateDisplay = document.getElementById('date-display');
     if (dateDisplay) {
         const options = { weekday: 'short', month: 'short', day: 'numeric' };
         dateDisplay.textContent = simulationTime.toLocaleDateString('en-US', options);
     }
 
-    // Visual feedback for time warp
-    if (isTimeWarping) {
-        timeDisplay.style.color = UI_CONFIG.timeWarningColor;
-        timeDisplay.style.textShadow = UI_CONFIG.timeWarningGlow;
-    } else {
-        timeDisplay.style.color = UI_CONFIG.timeNormalColor;
-        timeDisplay.style.textShadow = UI_CONFIG.timeNormalGlow;
-    }
+    timeDisplay.style.color = isTimeWarping ? UI_CONFIG.timeWarningColor : UI_CONFIG.timeNormalColor;
+    timeDisplay.style.textShadow = isTimeWarping ? UI_CONFIG.timeWarningGlow : UI_CONFIG.timeNormalGlow;
 
-    // Update past and forecast time headers
     const pastTime = new Date(simulationTime.getTime() - 3 * 3600 * 1000);
     const forecastTime = new Date(simulationTime.getTime() + 3 * 3600 * 1000);
 
     const pastDisplay = document.getElementById('past-time-display');
-    if (pastDisplay) {
-        pastDisplay.textContent = formatTime12(pastTime);
-    }
+    if (pastDisplay) pastDisplay.textContent = formatTime12(pastTime);
 
     const forecastDisplay = document.getElementById('forecast-time-display');
-    if (forecastDisplay) {
-        forecastDisplay.textContent = formatTime12(forecastTime);
-    }
+    if (forecastDisplay) forecastDisplay.textContent = formatTime12(forecastTime);
 }
 
-/**
- * Update weather display panels
- * @param {Object} data - Weather data
- * @param {Object} weatherService - WeatherService instance for temperature conversion
- */
+// ── updateWeatherDisplay ─────────────────────────────────────────────────────
 export function updateWeatherDisplay(data, weatherService) {
     if (!data) return;
 
-    const t = (c) => Math.round(weatherService.convertTemp(c));
+    const tRaw = (c) => Math.round(weatherService.convertTemp(c));
     const deg = '°';
 
-    // Center panel (current)
-    const locationEl = document.getElementById('location');
-    if (locationEl) {
-        locationEl.textContent = data.location || 'Unknown';
-    }
+    // Helper to countTo a temp element
+    const setTemp = (id, celsius) => {
+        const el = document.getElementById(id);
+        if (el && celsius != null) countTo(el, tRaw(celsius), deg);
+    };
 
+    // Helper to countTo a plain number element
+    const setNum = (id, val, suffix = '') => {
+        const el = document.getElementById(id);
+        if (el && val != null) countTo(el, Math.round(val), suffix);
+    };
+
+    const setText = (id, text) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = text;
+    };
+
+    // ── Location ──
+    setText('location', data.location || 'Unknown');
+
+    // ── Current (center) ──
     if (data.current) {
-        const desc = document.getElementById('current-description');
-        if (desc) desc.textContent = data.current.description;
+        setText('current-description', data.current.description);
+        setTemp('current-temp', data.current.temp);
+        setTemp('current-feels-like', data.current.apparentTemp ?? data.current.temp);
 
-        const temp = document.getElementById('current-temp');
-        if (temp) temp.textContent = `${t(data.current.temp)}${deg}`;
+        const uvEl = document.getElementById('current-uv');
+        if (uvEl) uvEl.textContent = `UV ${Math.round(data.current.uvIndex ?? 0)}`;
 
-        const wind = document.getElementById('current-wind');
-        if (wind) wind.textContent = `${Math.round(data.current.windSpeed)} km/h`;
+        setNum('current-wind', data.current.windSpeed, ' km/h');
+
+        // Wind compass
+        if (data.current.windDirection != null) {
+            updateWindCompass(data.current.windDirection);
+        }
     }
 
-    // Left panel (past)
+    // ── Past (left panel) ──
     if (data.past) {
-        const desc = document.getElementById('past-description');
-        if (desc) desc.textContent = data.past.description;
-
-        const temp = document.getElementById('past-temp');
-        if (temp) temp.textContent = `${t(data.past.temp)}${deg}`;
-
-        const wind = document.getElementById('past-wind');
-        if (wind) wind.textContent = `${Math.round(data.past.windSpeed)} km/h`;
-
-        const cloud = document.getElementById('past-cloud');
-        if (cloud) cloud.textContent = `${Math.round(data.past.cloudCover)}%`;
+        setText('past-description', data.past.description);
+        setTemp('past-temp', data.past.temp);
+        setTemp('past-feels-like', data.past.apparentTemp ?? data.past.temp);
+        setNum('past-wind', data.past.windSpeed, ' km/h');
+        setNum('past-humidity', data.past.humidity ?? 0, '%');
+        setNum('past-cloud', data.past.cloudCover, '%');
+        setNum('past-precip-prob', data.past.precipProb ?? 0, '%');
     }
 
-    // Right panel (forecast)
+    // ── Forecast (right panel) ──
     if (data.forecast) {
-        const desc = document.getElementById('forecast-description');
-        if (desc) desc.textContent = data.forecast.description;
-
-        const temp = document.getElementById('forecast-temp');
-        if (temp) temp.textContent = `${t(data.forecast.temp)}${deg}`;
-
-        const wind = document.getElementById('forecast-wind');
-        if (wind) wind.textContent = `${Math.round(data.forecast.windSpeed)} km/h`;
-
-        const cloud = document.getElementById('forecast-cloud');
-        if (cloud) cloud.textContent = `${Math.round(data.forecast.cloudCover)}%`;
+        setText('forecast-description', data.forecast.description);
+        setTemp('forecast-temp', data.forecast.temp);
+        setTemp('forecast-feels-like', data.forecast.apparentTemp ?? data.forecast.temp);
+        setNum('forecast-wind', data.forecast.windSpeed, ' km/h');
+        setNum('forecast-humidity', data.forecast.humidity ?? 0, '%');
+        setNum('forecast-cloud', data.forecast.cloudCover, '%');
+        setNum('forecast-precip-prob', data.forecast.precipProb ?? 0, '%');
     }
 
-    // Moon phase
+    // ── Moon phase ──
     const mp = calculateMoonPhase();
-    const moonPhaseEl = document.getElementById('moon-phase');
-    if (moonPhaseEl) {
-        moonPhaseEl.textContent = mp.phaseName;
-    }
+    setText('moon-phase', mp.phaseName);
 
-    // Advanced panel: historical
+    // ── Sunrise / Sunset ──
+    if (data.sunrise) setText('sunrise-time', formatTime12(new Date(data.sunrise)));
+    if (data.sunset)  setText('sunset-time',  formatTime12(new Date(data.sunset)));
+
+    // ── Advanced: historical year-ago ──
     if (data.historicalYearAgo) {
-        const histTemp = document.getElementById('history-temp');
-        if (histTemp) histTemp.textContent = `${t(data.historicalYearAgo.temp)}${deg}`;
-
-        const histDesc = document.getElementById('history-desc');
-        if (histDesc) histDesc.textContent = data.historicalYearAgo.description;
+        setTemp('history-temp', data.historicalYearAgo.temp);
+        setText('history-desc', data.historicalYearAgo.description);
     }
 
-    // Advanced panel: accuracy
+    // ── Advanced: accuracy ──
     if (data.accuracy) {
         let delta = data.accuracy.delta;
-        if (weatherService.unit === 'imperial') {
-            delta = delta * 1.8;
-        }
-
+        if (weatherService.unit === 'imperial') delta *= 1.8;
         const sign = delta > 0 ? '+' : (delta < 0 ? '-' : '');
         const deltaEl = document.getElementById('accuracy-delta');
         if (deltaEl) {
             deltaEl.textContent = `${sign}${Math.abs(delta).toFixed(1)}${deg}`;
-            const color = Math.abs(data.accuracy.delta) < 2 ? '#44ff44' : '#ff4444';
-            deltaEl.style.color = color;
+            deltaEl.style.color = Math.abs(data.accuracy.delta) < 2 ? '#44ff44' : '#ff4444';
         }
-
-        const scoreEl = document.getElementById('accuracy-score');
-        if (scoreEl) {
-            scoreEl.textContent = `Score: ${data.accuracy.accuracy}%`;
-        }
+        setText('accuracy-score', `Score: ${data.accuracy.accuracy}%`);
     }
 
-    // Regional data
+    // ── Advanced: regional ──
     if (data.regional) {
         const list = document.getElementById('regional-list');
         if (list) {
             list.innerHTML = '';
             data.regional.forEach(reg => {
                 const div = document.createElement('div');
-                div.innerHTML = `<b>${reg.name}:</b> ${t(reg.temp)}${deg}`;
+                div.innerHTML = `<b>${reg.name}:</b> ${tRaw(reg.temp)}${deg}`;
                 list.appendChild(div);
             });
         }
     }
 }
 
-/**
- * Update unit toggle button text
- * @param {Object} weatherService - WeatherService instance
- */
+// ── updateUnitButton ─────────────────────────────────────────────────────────
 export function updateUnitButton(weatherService) {
-    const btn = document.getElementById('unit-toggle');
-    if (!btn) return;
-
-    const nextUnit = weatherService.unit === 'metric' ? '°F' : '°C';
-    btn.textContent = `Switch to ${nextUnit}`;
+    const toggle = document.getElementById('unit-toggle');
+    if (!toggle) return;
+    toggle.setAttribute('data-unit', weatherService.unit);
+    toggle.setAttribute('aria-label', `Toggle unit — currently ${weatherService.unit === 'metric' ? 'Celsius' : 'Fahrenheit'}`);
 }
 
-/**
- * Setup all event listeners
- * @param {Object} callbacks - Object with callback functions
- */
+// ── setupEventListeners ──────────────────────────────────────────────────────
 export function setupEventListeners(callbacks) {
-    // Retry location button
     const retryBtn = document.getElementById('retry-location');
-    if (retryBtn) {
-        retryBtn.addEventListener('click', callbacks.onRetryLocation);
-    }
+    if (retryBtn) retryBtn.addEventListener('click', callbacks.onRetryLocation);
 
-    // Unit toggle button
-    const unitBtn = document.getElementById('unit-toggle');
-    if (unitBtn) {
-        unitBtn.addEventListener('click', callbacks.onToggleUnit);
-    }
-
-    // Location search
-    const searchInput = document.getElementById('location-search');
-    const searchBtn = document.getElementById('search-btn');
-
-    if (searchBtn) {
-        searchBtn.addEventListener('click', () => {
-            callbacks.onSearch(searchInput?.value || '');
-        });
-    }
-
-    if (searchInput) {
-        searchInput.addEventListener('keypress', (e) => {
-            if (e.key === 'Enter') {
-                callbacks.onSearch(searchInput.value);
+    const unitToggle = document.getElementById('unit-toggle');
+    if (unitToggle) {
+        unitToggle.addEventListener('click', callbacks.onToggleUnit);
+        unitToggle.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                callbacks.onToggleUnit();
             }
         });
     }
 
-    // Time warp button
-    const warpBtn = document.getElementById('time-warp-btn');
-    if (warpBtn) {
-        warpBtn.addEventListener('click', callbacks.onToggleTimeWarp);
+    const searchInput = document.getElementById('location-search');
+    const searchBtn = document.getElementById('search-btn');
+
+    if (searchBtn) {
+        searchBtn.addEventListener('click', () => callbacks.onSearch(searchInput?.value || ''));
     }
+    if (searchInput) {
+        searchInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') callbacks.onSearch(searchInput.value);
+        });
+    }
+
+    const warpBtn = document.getElementById('time-warp-btn');
+    if (warpBtn) warpBtn.addEventListener('click', callbacks.onToggleTimeWarp);
 }
 
-/**
- * Update time warp button appearance
- * @param {boolean} isActive - Whether time warp is active
- */
+// ── updateTimeWarpButton ─────────────────────────────────────────────────────
 export function updateTimeWarpButton(isActive) {
     const warpBtn = document.getElementById('time-warp-btn');
     if (!warpBtn) return;
-
-    warpBtn.style.background = isActive
-        ? UI_CONFIG.timeWarpColorActive
-        : UI_CONFIG.timeWarpColorInactive;
-    warpBtn.textContent = isActive
-        ? UI_CONFIG.timeWarpSymbolActive
-        : UI_CONFIG.timeWarpSymbolInactive;
+    warpBtn.style.background = isActive ? UI_CONFIG.timeWarpColorActive : UI_CONFIG.timeWarpColorInactive;
+    warpBtn.textContent = isActive ? UI_CONFIG.timeWarpSymbolActive : UI_CONFIG.timeWarpSymbolInactive;
 }
 
-/**
- * Set search button loading state
- * @param {boolean} isLoading - Whether search is in progress
- */
+// ── setSearchLoading ──────────────────────────────────────────────────────────
 export function setSearchLoading(isLoading) {
     const searchBtn = document.getElementById('search-btn');
-    if (searchBtn) {
-        searchBtn.textContent = isLoading ? '...' : 'Go';
+    if (searchBtn) searchBtn.textContent = isLoading ? '...' : 'Go';
+}
+
+// ── updateWindCompass ────────────────────────────────────────────────────────
+export function updateWindCompass(degrees) {
+    const arrow = document.getElementById('wind-arrow');
+    if (!arrow) return;
+    arrow.style.transform = `rotate(${degrees}deg)`;
+}
+
+// ── updatePanelTheme ─────────────────────────────────────────────────────────
+// dayFactor: -1 = deep night, 0 = dawn/dusk, 1 = noon
+// weatherSeverity: 0 = clear, 1 = storm
+// tempTrend: -1 = much cooler than year-ago, +1 = much warmer
+export function updatePanelTheme(dayFactor, weatherSeverity, tempTrend = 0) {
+    const root = document.documentElement;
+    const day = Math.max(-1, Math.min(1, dayFactor || 0));
+    const sev = Math.max(0, Math.min(1, weatherSeverity || 0));
+    const trend = Math.max(-1, Math.min(1, tempTrend || 0));
+
+    let panelBg, panelBorder, headerColor;
+
+    if (day < -0.15) {
+        // Night — deep navy glass
+        panelBg = `rgba(5, 10, 40, ${0.65 + sev * 0.15})`;
+        panelBorder = `rgba(60, 100, 200, ${0.2 + sev * 0.1})`;
+        headerColor = `hsl(220, ${60 - sev * 20}%, ${55 - sev * 15}%)`;
+    } else if (day < 0.15) {
+        // Dawn / Dusk — warm amber tint
+        panelBg = `rgba(30, 15, 5, ${0.60 + sev * 0.15})`;
+        panelBorder = `rgba(220, 140, 40, ${0.25 + sev * 0.1})`;
+        headerColor = `hsl(${38 - sev * 15}, ${70 - sev * 20}%, ${65 - sev * 15}%)`;
+    } else {
+        // Day — sky-blue tint, stormy grey when severe
+        panelBg = `rgba(0, 20, 60, ${0.55 + sev * 0.20})`;
+        panelBorder = `rgba(100, 180, 255, ${0.15 + sev * 0.10})`;
+        headerColor = `hsl(${200 + sev * 10}, ${80 - sev * 30}%, ${70 - sev * 20}%)`;
     }
+
+    root.style.setProperty('--panel-bg', panelBg);
+    root.style.setProperty('--panel-border', panelBorder);
+    root.style.setProperty('--header-color', headerColor);
+
+    // Temperature trend — warm (orange) glow when above long-term average, cool (blue) when below
+    const strength = Math.abs(trend);
+    if (strength > 0.05) {
+        const r = trend > 0 ? 255 : 60;
+        const g = 120;
+        const b = trend > 0 ? 60 : 255;
+        root.style.setProperty('--trend-glow', `rgba(${r}, ${g}, ${b}, ${strength * 0.45})`);
+    } else {
+        root.style.setProperty('--trend-glow', 'transparent');
+    }
+}
+
+// ── drawSparkline ─────────────────────────────────────────────────────────────
+// Draws a ±6 h bezier temperature curve on #sparkline canvas.
+export function drawSparkline(simulationTime, weatherData, weatherService) {
+    const canvas = document.getElementById('sparkline');
+    if (!canvas || !weatherData || !weatherData.timeline) return;
+
+    const ctx = canvas.getContext('2d');
+    const W = canvas.width;
+    const H = canvas.height;
+    ctx.clearRect(0, 0, W, H);
+
+    const startMs = simulationTime.getTime() - 6 * 3600 * 1000;
+    const endMs   = simulationTime.getTime() + 6 * 3600 * 1000;
+    const spanMs  = endMs - startMs;
+
+    // Sample every 30 min
+    const pts = [];
+    for (let t = startMs; t <= endMs; t += 30 * 60 * 1000) {
+        const w = getWeatherAtTime(new Date(t), weatherData.timeline);
+        if (w) {
+            const dispTemp = weatherService ? weatherService.convertTemp(w.temp) : w.temp;
+            pts.push({ t, y: dispTemp });
+        }
+    }
+    if (pts.length < 2) return;
+
+    const temps = pts.map(p => p.y);
+    const minT = Math.min(...temps) - 2;
+    const maxT = Math.max(...temps) + 2;
+    const rangeT = maxT - minT || 1;
+    const PAD = 10;
+
+    const toX = (ms) => PAD + ((ms - startMs) / spanMs) * (W - PAD * 2);
+    const toY = (temp) => H - PAD - ((temp - minT) / rangeT) * (H - PAD * 2);
+
+    // Filled area
+    ctx.beginPath();
+    ctx.moveTo(toX(pts[0].t), toY(pts[0].y));
+    for (let i = 1; i < pts.length; i++) {
+        const cpX = (toX(pts[i - 1].t) + toX(pts[i].t)) / 2;
+        ctx.bezierCurveTo(cpX, toY(pts[i - 1].y), cpX, toY(pts[i].y), toX(pts[i].t), toY(pts[i].y));
+    }
+    ctx.lineTo(toX(pts[pts.length - 1].t), H);
+    ctx.lineTo(toX(pts[0].t), H);
+    ctx.closePath();
+    const grad = ctx.createLinearGradient(0, 0, 0, H);
+    grad.addColorStop(0, 'rgba(100, 200, 255, 0.35)');
+    grad.addColorStop(1, 'rgba(100, 200, 255, 0.0)');
+    ctx.fillStyle = grad;
+    ctx.fill();
+
+    // Stroke
+    ctx.beginPath();
+    ctx.moveTo(toX(pts[0].t), toY(pts[0].y));
+    for (let i = 1; i < pts.length; i++) {
+        const cpX = (toX(pts[i - 1].t) + toX(pts[i].t)) / 2;
+        ctx.bezierCurveTo(cpX, toY(pts[i - 1].y), cpX, toY(pts[i].y), toX(pts[i].t), toY(pts[i].y));
+    }
+    ctx.strokeStyle = 'rgba(130, 215, 255, 0.9)';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    // "Now" dot
+    const nowW = getWeatherAtTime(simulationTime, weatherData.timeline);
+    if (nowW) {
+        const nx = toX(simulationTime.getTime());
+        const ny = toY(weatherService ? weatherService.convertTemp(nowW.temp) : nowW.temp);
+        ctx.beginPath();
+        ctx.arc(nx, ny, 3.5, 0, Math.PI * 2);
+        ctx.fillStyle = '#fff';
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(130, 215, 255, 0.9)';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+    }
+
+    // Endpoint labels
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    ctx.font = `9px Inter, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.fillText(`${Math.round(pts[0].y)}°`, 2, toY(pts[0].y) - 3);
+    ctx.textAlign = 'right';
+    ctx.fillText(`${Math.round(pts[pts.length - 1].y)}°`, W - 2, toY(pts[pts.length - 1].y) - 3);
 }
 
 export { UI_CONFIG };

--- a/src/weather-simulation.js
+++ b/src/weather-simulation.js
@@ -56,17 +56,23 @@ export function getWeatherAtTime(time, timeline) {
     if (windDir < 0) windDir += 360;
     if (windDir >= 360) windDir -= 360;
 
+    const lerp = (a, b) => (a || 0) + ((b || 0) - (a || 0)) * factor;
+
     return {
-        temp: prev.temp + (next.temp - prev.temp) * factor,
+        temp: lerp(prev.temp, next.temp),
+        apparentTemp: lerp(prev.apparentTemp ?? prev.temp, next.apparentTemp ?? next.temp),
+        humidity: lerp(prev.humidity, next.humidity),
+        uvIndex: lerp(prev.uvIndex, next.uvIndex),
+        precipProb: lerp(prev.precipProb, next.precipProb),
         weatherCode: weatherCode,
         description: description,
-        cloudCover: prev.cloudCover + (next.cloudCover - prev.cloudCover) * factor,
-        windSpeed: prev.windSpeed + (next.windSpeed - prev.windSpeed) * factor,
+        cloudCover: lerp(prev.cloudCover, next.cloudCover),
+        windSpeed: lerp(prev.windSpeed, next.windSpeed),
         windDirection: windDir,
-        visibility: (prev.visibility || 10000) + ((next.visibility || 10000) - (prev.visibility || 10000)) * factor,
-        rain: (prev.rain || 0) + ((next.rain || 0) - (prev.rain || 0)) * factor,
-        showers: (prev.showers || 0) + ((next.showers || 0) - (prev.showers || 0)) * factor,
-        snowfall: (prev.snowfall || 0) + ((next.snowfall || 0) - (prev.snowfall || 0)) * factor,
+        visibility: lerp(prev.visibility ?? 10000, next.visibility ?? 10000),
+        rain: lerp(prev.rain, next.rain),
+        showers: lerp(prev.showers, next.showers),
+        snowfall: lerp(prev.snowfall, next.snowfall),
         severity: severity
     };
 }

--- a/src/weather.js
+++ b/src/weather.js
@@ -1,6 +1,7 @@
+import SunCalc from 'suncalc';
+
 export class WeatherService {
     constructor() {
-        // Open-Meteo API is free and doesn't require an API key
         this.latitude = null;
         this.longitude = null;
         this.location = null;
@@ -19,7 +20,7 @@ export class WeatherService {
 
     convertTemp(celsius) {
         if (this.unit === 'metric') return celsius;
-        return (celsius * 9/5) + 32;
+        return (celsius * 9 / 5) + 32;
     }
 
     async searchLocation(query) {
@@ -42,7 +43,7 @@ export class WeatherService {
     }
 
     async getLocation() {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             if (!navigator.geolocation) {
                 this.setDefaultLocation();
                 resolve();
@@ -53,15 +54,14 @@ export class WeatherService {
                 async (position) => {
                     this.latitude = position.coords.latitude;
                     this.longitude = position.coords.longitude;
-                    
-                    // Get location name using reverse geocoding
+
                     try {
                         const locationName = await this.reverseGeocode(this.latitude, this.longitude);
                         this.location = locationName;
                     } catch (error) {
                         this.location = `${this.latitude.toFixed(2)}, ${this.longitude.toFixed(2)}`;
                     }
-                    
+
                     resolve();
                 },
                 (error) => {
@@ -74,7 +74,6 @@ export class WeatherService {
     }
 
     setDefaultLocation() {
-        // Default to New York City coordinates
         this.latitude = 40.7128;
         this.longitude = -74.0060;
         this.location = 'New York, USA (default)';
@@ -86,7 +85,7 @@ export class WeatherService {
                 `https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}`
             );
             const data = await response.json();
-            
+
             if (data.address) {
                 const city = data.address.city || data.address.town || data.address.village;
                 const country = data.address.country;
@@ -99,103 +98,131 @@ export class WeatherService {
         }
     }
 
+    // Parse a single hourly data point including all new fields
+    _parseHourlyPoint(hourly, i) {
+        return {
+            temp: hourly.temperature_2m[i],
+            apparentTemp: hourly.apparent_temperature ? hourly.apparent_temperature[i] : hourly.temperature_2m[i],
+            humidity: hourly.relative_humidity_2m ? hourly.relative_humidity_2m[i] : 0,
+            uvIndex: hourly.uv_index ? hourly.uv_index[i] : 0,
+            precipProb: hourly.precipitation_probability ? hourly.precipitation_probability[i] : 0,
+            weatherCode: hourly.weather_code[i],
+            description: this.getWeatherDescription(hourly.weather_code[i]),
+            cloudCover: hourly.cloud_cover[i],
+            windSpeed: hourly.wind_speed_10m[i],
+            windDirection: hourly.wind_direction_10m ? hourly.wind_direction_10m[i] : 0,
+            visibility: hourly.visibility ? hourly.visibility[i] : 10000,
+            rain: hourly.rain ? hourly.rain[i] : 0,
+            showers: hourly.showers ? hourly.showers[i] : 0,
+            snowfall: hourly.snowfall ? hourly.snowfall[i] : 0
+        };
+    }
+
     async fetchWeather() {
         if (!this.latitude || !this.longitude) {
             throw new Error('Location not available');
         }
 
         try {
-            // Using Open-Meteo API (free, no key required)
-            // Get current and forecast weather
-            // Added 'visibility' to current params
-            // Request past_days=1 to ensure we have historical hourly data for the "Past" zone interpolation
-            // even if the current time is just after midnight.
-            const currentResponse = await fetch(
-                `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(this.latitude)}&longitude=${encodeURIComponent(this.longitude)}&current=temperature_2m,weather_code,cloud_cover,wind_speed_10m,wind_direction_10m,visibility,rain,showers,snowfall&hourly=temperature_2m,weather_code,cloud_cover,wind_speed_10m,wind_direction_10m,visibility,rain,showers,snowfall&timezone=auto&past_days=1`
-            );
+            const now = new Date();
+
+            // Forecast API — extended with apparent temp, humidity, UV, precip probability
+            const forecastUrl = [
+                'https://api.open-meteo.com/v1/forecast',
+                `?latitude=${encodeURIComponent(this.latitude)}`,
+                `&longitude=${encodeURIComponent(this.longitude)}`,
+                '&current=temperature_2m,apparent_temperature,relative_humidity_2m,uv_index,precipitation_probability,weather_code,cloud_cover,wind_speed_10m,wind_direction_10m,visibility,rain,showers,snowfall',
+                '&hourly=temperature_2m,apparent_temperature,relative_humidity_2m,uv_index,precipitation_probability,weather_code,cloud_cover,wind_speed_10m,wind_direction_10m,visibility,rain,showers,snowfall',
+                '&timezone=auto&past_days=1'
+            ].join('');
+
+            const currentResponse = await fetch(forecastUrl);
             const currentData = await currentResponse.json();
 
-            // Get historical weather (past 3 hours)
-            const now = new Date();
+            // Archive API — no UV/precipProb in archive, use apparent_temp + humidity
             const pastDate = new Date(now.getTime() - 3 * 60 * 60 * 1000);
             const pastDateStr = pastDate.toISOString().split('T')[0];
             const todayStr = now.toISOString().split('T')[0];
-            
+
             const historicalResponse = await fetch(
-                `https://archive-api.open-meteo.com/v1/archive?latitude=${encodeURIComponent(this.latitude)}&longitude=${encodeURIComponent(this.longitude)}&start_date=${pastDateStr}&end_date=${todayStr}&hourly=temperature_2m,weather_code,cloud_cover,wind_speed_10m,wind_direction_10m,rain,showers,snowfall&timezone=auto`
+                `https://archive-api.open-meteo.com/v1/archive?latitude=${encodeURIComponent(this.latitude)}&longitude=${encodeURIComponent(this.longitude)}&start_date=${pastDateStr}&end_date=${todayStr}&hourly=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,cloud_cover,wind_speed_10m,wind_direction_10m,rain,showers,snowfall&timezone=auto`
             );
             const historicalData = await historicalResponse.json();
 
-            // Create Timeline (Hourly Data)
-            // Combine historical (past hours) and current/forecast (future hours) if needed
-            // But Open-Meteo Forecast usually provides full day hourly data including past hours of the day.
-            // Let's verify: Forecast returns 7 days by default. Hourly array covers 00:00 to 23:00+...
-
+            // Build hourly timeline
             const timeline = [];
             const hourly = currentData.hourly;
-
             if (hourly && hourly.time) {
                 for (let i = 0; i < hourly.time.length; i++) {
                     timeline.push({
                         time: new Date(hourly.time[i]),
-                        temp: hourly.temperature_2m[i],
-                        weatherCode: hourly.weather_code[i],
-                        description: this.getWeatherDescription(hourly.weather_code[i]),
-                        cloudCover: hourly.cloud_cover[i],
-                        windSpeed: hourly.wind_speed_10m[i],
-                        windDirection: hourly.wind_direction_10m ? hourly.wind_direction_10m[i] : 0,
-                        visibility: hourly.visibility ? hourly.visibility[i] : 10000,
-                        rain: hourly.rain ? hourly.rain[i] : 0,
-                        showers: hourly.showers ? hourly.showers[i] : 0,
-                        snowfall: hourly.snowfall ? hourly.snowfall[i] : 0
+                        ...this._parseHourlyPoint(hourly, i)
                     });
                 }
             }
 
-            // Parse current weather
+            // Current conditions
+            const cur = currentData.current;
             const current = {
-                temp: currentData.current.temperature_2m,
-                weatherCode: currentData.current.weather_code,
-                description: this.getWeatherDescription(currentData.current.weather_code),
-                cloudCover: currentData.current.cloud_cover,
-                windSpeed: currentData.current.wind_speed_10m,
-                windDirection: currentData.current.wind_direction_10m || 0,
-                visibility: currentData.current.visibility, // meters
-                rain: currentData.current.rain,
-                showers: currentData.current.showers,
-                snowfall: currentData.current.snowfall
+                temp: cur.temperature_2m,
+                apparentTemp: cur.apparent_temperature ?? cur.temperature_2m,
+                humidity: cur.relative_humidity_2m ?? 0,
+                uvIndex: cur.uv_index ?? 0,
+                precipProb: cur.precipitation_probability ?? 0,
+                weatherCode: cur.weather_code,
+                description: this.getWeatherDescription(cur.weather_code),
+                cloudCover: cur.cloud_cover,
+                windSpeed: cur.wind_speed_10m,
+                windDirection: cur.wind_direction_10m ?? 0,
+                visibility: cur.visibility,
+                rain: cur.rain,
+                showers: cur.showers,
+                snowfall: cur.snowfall
             };
 
-            // Parse past weather (3 hours ago)
-            const pastHourIndex = this.findClosestHourIndex(historicalData.hourly.time, pastDate);
+            // Past conditions (3 h ago, from archive)
+            const hist = historicalData.hourly;
+            const pastIdx = this.findClosestHourIndex(hist.time, pastDate);
             const past = {
-                temp: historicalData.hourly.temperature_2m[pastHourIndex] || current.temp,
-                weatherCode: historicalData.hourly.weather_code[pastHourIndex] || current.weatherCode,
-                description: this.getWeatherDescription(historicalData.hourly.weather_code[pastHourIndex] || current.weatherCode),
-                cloudCover: historicalData.hourly.cloud_cover[pastHourIndex] || current.cloudCover,
-                windSpeed: historicalData.hourly.wind_speed_10m[pastHourIndex] || current.windSpeed,
-                windDirection: historicalData.hourly.wind_direction_10m ? historicalData.hourly.wind_direction_10m[pastHourIndex] : (current.windDirection || 0),
-                rain: historicalData.hourly.rain ? historicalData.hourly.rain[pastHourIndex] : 0,
-                showers: historicalData.hourly.showers ? historicalData.hourly.showers[pastHourIndex] : 0,
-                snowfall: historicalData.hourly.snowfall ? historicalData.hourly.snowfall[pastHourIndex] : 0
+                temp: hist.temperature_2m[pastIdx] ?? current.temp,
+                apparentTemp: hist.apparent_temperature ? (hist.apparent_temperature[pastIdx] ?? current.apparentTemp) : current.apparentTemp,
+                humidity: hist.relative_humidity_2m ? (hist.relative_humidity_2m[pastIdx] ?? current.humidity) : current.humidity,
+                uvIndex: 0,      // Not available in archive
+                precipProb: 0,   // Not available in archive
+                weatherCode: hist.weather_code[pastIdx] ?? current.weatherCode,
+                description: this.getWeatherDescription(hist.weather_code[pastIdx] ?? current.weatherCode),
+                cloudCover: hist.cloud_cover[pastIdx] ?? current.cloudCover,
+                windSpeed: hist.wind_speed_10m[pastIdx] ?? current.windSpeed,
+                windDirection: hist.wind_direction_10m ? (hist.wind_direction_10m[pastIdx] ?? current.windDirection) : current.windDirection,
+                rain: hist.rain ? (hist.rain[pastIdx] ?? 0) : 0,
+                showers: hist.showers ? (hist.showers[pastIdx] ?? 0) : 0,
+                snowfall: hist.snowfall ? (hist.snowfall[pastIdx] ?? 0) : 0
             };
 
-            // Parse forecast (3 hours from now)
+            // Forecast conditions (+3 h)
             const futureDate = new Date(now.getTime() + 3 * 60 * 60 * 1000);
-            const futureHourIndex = this.findClosestHourIndex(currentData.hourly.time, futureDate);
+            const futureIdx = this.findClosestHourIndex(currentData.hourly.time, futureDate);
+            const fc = currentData.hourly;
             const forecast = {
-                temp: currentData.hourly.temperature_2m[futureHourIndex] || current.temp,
-                weatherCode: currentData.hourly.weather_code[futureHourIndex] || current.weatherCode,
-                description: this.getWeatherDescription(currentData.hourly.weather_code[futureHourIndex] || current.weatherCode),
-                cloudCover: currentData.hourly.cloud_cover[futureHourIndex] || current.cloudCover,
-                windSpeed: currentData.hourly.wind_speed_10m[futureHourIndex] || current.windSpeed,
-                windDirection: currentData.hourly.wind_direction_10m ? currentData.hourly.wind_direction_10m[futureHourIndex] : (current.windDirection || 0),
-                rain: currentData.hourly.rain ? currentData.hourly.rain[futureHourIndex] : 0,
-                showers: currentData.hourly.showers ? currentData.hourly.showers[futureHourIndex] : 0,
-                snowfall: currentData.hourly.snowfall ? currentData.hourly.snowfall[futureHourIndex] : 0
+                temp: fc.temperature_2m[futureIdx] ?? current.temp,
+                apparentTemp: fc.apparent_temperature ? (fc.apparent_temperature[futureIdx] ?? current.apparentTemp) : current.apparentTemp,
+                humidity: fc.relative_humidity_2m ? (fc.relative_humidity_2m[futureIdx] ?? current.humidity) : current.humidity,
+                uvIndex: fc.uv_index ? (fc.uv_index[futureIdx] ?? 0) : 0,
+                precipProb: fc.precipitation_probability ? (fc.precipitation_probability[futureIdx] ?? 0) : 0,
+                weatherCode: fc.weather_code[futureIdx] ?? current.weatherCode,
+                description: this.getWeatherDescription(fc.weather_code[futureIdx] ?? current.weatherCode),
+                cloudCover: fc.cloud_cover[futureIdx] ?? current.cloudCover,
+                windSpeed: fc.wind_speed_10m[futureIdx] ?? current.windSpeed,
+                windDirection: fc.wind_direction_10m ? (fc.wind_direction_10m[futureIdx] ?? current.windDirection) : current.windDirection,
+                rain: fc.rain ? (fc.rain[futureIdx] ?? 0) : 0,
+                showers: fc.showers ? (fc.showers[futureIdx] ?? 0) : 0,
+                snowfall: fc.snowfall ? (fc.snowfall[futureIdx] ?? 0) : 0
             };
 
-            // Advanced Data Fetches
+            // Sunrise/sunset via SunCalc
+            const sunTimes = SunCalc.getTimes(now, this.latitude, this.longitude);
+
+            // Advanced data
             const historicalYearAgo = await this.fetchHistoricalYearAgo(now);
             const regional = await this.fetchRegionalWeather();
             const accuracy = this.getPredictionAccuracy(current);
@@ -205,7 +232,9 @@ export class WeatherService {
                 current,
                 past,
                 forecast,
-                timeline, // Add timeline to return
+                timeline,
+                sunrise: sunTimes.sunrise,
+                sunset: sunTimes.sunset,
                 historicalYearAgo,
                 regional,
                 accuracy
@@ -226,35 +255,32 @@ export class WeatherService {
                 `https://archive-api.open-meteo.com/v1/archive?latitude=${encodeURIComponent(this.latitude)}&longitude=${encodeURIComponent(this.longitude)}&start_date=${dateStr}&end_date=${dateStr}&hourly=temperature_2m,weather_code,cloud_cover,wind_speed_10m&timezone=auto`
             );
             const data = await response.json();
-
-            // Use same hour as now
             const index = this.findClosestHourIndex(data.hourly.time, lastYear);
-             return {
+            return {
                 temp: data.hourly.temperature_2m[index],
                 weatherCode: data.hourly.weather_code[index],
                 description: this.getWeatherDescription(data.hourly.weather_code[index]),
                 date: dateStr
             };
         } catch (e) {
-            console.error("Failed to fetch historical year ago", e);
+            console.error('Failed to fetch historical year ago', e);
             return null;
         }
     }
 
     async fetchRegionalWeather() {
-        // Offsets approx 10-15km
         const offsets = [
-            { name: "North", lat: 0.1, lon: 0 },
-            { name: "East", lat: 0, lon: 0.1 },
-            { name: "South", lat: -0.1, lon: 0 },
-            { name: "West", lat: 0, lon: -0.1 }
+            { name: 'North', lat: 0.1, lon: 0 },
+            { name: 'East', lat: 0, lon: 0.1 },
+            { name: 'South', lat: -0.1, lon: 0 },
+            { name: 'West', lat: 0, lon: -0.1 }
         ];
 
         const promises = offsets.map(async (offset) => {
-             const rLat = this.latitude + offset.lat;
-             const rLon = this.longitude + offset.lon;
-             try {
-                 const response = await fetch(
+            const rLat = this.latitude + offset.lat;
+            const rLon = this.longitude + offset.lon;
+            try {
+                const response = await fetch(
                     `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(rLat)}&longitude=${encodeURIComponent(rLon)}&current=temperature_2m,weather_code&timezone=auto`
                 );
                 const data = await response.json();
@@ -264,9 +290,9 @@ export class WeatherService {
                     weatherCode: data.current.weather_code,
                     description: this.getWeatherDescription(data.current.weather_code)
                 };
-             } catch (e) {
-                 return null;
-             }
+            } catch (e) {
+                return null;
+            }
         });
 
         const results = await Promise.all(promises);
@@ -274,18 +300,13 @@ export class WeatherService {
     }
 
     getPredictionAccuracy(current) {
-         // Mock data for testing/demo purposes as requested
-         // Simulate a prediction that was slightly off
-         // Ensure it's deterministic enough for a single session but varies slightly
-         const delta = (Math.random() * 4) - 2; // -2 to +2
-         const predictedTemp = current.temp + delta;
-
-         return {
-             predictedTemp: parseFloat(predictedTemp.toFixed(1)),
-             actualTemp: current.temp,
-             delta: parseFloat(delta.toFixed(1)),
-             accuracy: Math.max(0, 100 - Math.abs(delta) * 10).toFixed(0)
-         };
+        const delta = (Math.random() * 4) - 2;
+        return {
+            predictedTemp: parseFloat((current.temp + delta).toFixed(1)),
+            actualTemp: current.temp,
+            delta: parseFloat(delta.toFixed(1)),
+            accuracy: Math.max(0, 100 - Math.abs(delta) * 10).toFixed(0)
+        };
     }
 
     findClosestHourIndex(timeArray, targetDate) {
@@ -294,8 +315,7 @@ export class WeatherService {
         let closestDiff = Infinity;
 
         for (let i = 0; i < timeArray.length; i++) {
-            const time = new Date(timeArray[i]).getTime();
-            const diff = Math.abs(time - targetTime);
+            const diff = Math.abs(new Date(timeArray[i]).getTime() - targetTime);
             if (diff < closestDiff) {
                 closestDiff = diff;
                 closestIndex = i;
@@ -306,7 +326,6 @@ export class WeatherService {
     }
 
     getWeatherDescription(code) {
-        // WMO Weather interpretation codes
         const weatherCodes = {
             0: 'Clear sky',
             1: 'Mainly clear',


### PR DESCRIPTION
Phase 1 — API Enrichment (weather.js)
  - Add apparent_temperature, relative_humidity_2m, uv_index, precipitation_probability to Open-Meteo current + hourly params
  - Refactor parsing into _parseHourlyPoint() helper
  - Attach sunrise/sunset from SunCalc.getTimes() to returned data

Phase 2 — New Data Displayed (index.html + ui.js)
  - Center panel: Feels Like + UV index badge below temp
  - Side panels: Humidity % and Precipitation Probability % rows
  - Center stats pill: sunrise 🌅 and sunset 🌇 times

Phase 3 — Aesthetic Polish (index.html + ui.js)
  - Inter font via Google Fonts
  - CSS custom properties: --panel-bg, --panel-border, --header-color, --trend-glow
  - updatePanelTheme(): night/dawn/day/storm tinting of panels (~2 Hz)
  - h3 color driven by --header-color (removed hard-coded #88d8f9)
  - countTo(): rAF-driven 800 ms ease-out number animation on all temps/stats
  - Unit toggle redesigned as a CSS sliding switch (same DOM id, same listener)
  - Stats.js hidden by default; backtick ` key toggles; DEV corner hint

Phase 4 — 12-Hour Sparkline (ui.js + index.html)
  - <canvas id="sparkline"> below current-description in center panel
  - drawSparkline(): bezier temperature curve ±6 h, filled gradient, "now" dot, endpoint labels; redraws on data load and each sim-hour tick

Phase 5 — Wind Direction Compass (ui.js + index.html)
  - Replaced 💨 emoji with inline SVG circle + direction arrow
  - updateWindCompass(deg) rotates the arrow with CSS transition

Phase 6 — Camera Orbit Controls (rendering.js + animation.js)
  - OrbitControls with damping, minDistance=4, maxDistance=30, maxPolarAngle=π/2; controls.update() called each frame

Extra — Temperature Trend Glow
  - Panel box-shadow tints warm orange when current temp > year-ago, cool blue when below; clamped ±1 over a 10°C swing

https://claude.ai/code/session_01Fn58JxTqHzYTKxQkhUKUXF