### PR TITLE
Beautify 10-day timeline: thermal aura, wind streaks, frost shimmer, day labels

### DIFF
--- a/src/timeline/DayColumn.js
+++ b/src/timeline/DayColumn.js
@@ -42,7 +42,8 @@ const dayColumnFragmentShader = `
   uniform float uZScore;
   uniform float uTime;
   uniform float uGlowIntensity;
-  
+  uniform float uWindStrength;  // 0..1 normalized wind speed
+
   varying vec2 vUv;
   varying float vHeight;
   varying vec3 vWorldPosition;
@@ -79,23 +80,45 @@ const dayColumnFragmentShader = `
   void main() {
     // Get base temperature color from z-score
     vec3 tempColor = getTemperatureColor(uZScore);
-    
-    // Add vertical gradient based on temp range (min at bottom, max at top)
-    vec3 bottomTint = tempColor * 0.7;  // Darker at bottom
-    vec3 topTint = tempColor * 1.3;      // Brighter at top
-    vec3 gradientColor = mix(bottomTint, topTint, vTempRatio);
-    
-    // Add subtle pulsing glow effect
-    float pulse = 1.0 + sin(uTime * 2.0) * 0.05 * uGlowIntensity;
+
+    // Vertical gradient: cooler/darker at base, hotter/brighter at top
+    vec3 bottomTint = tempColor * 0.55;
+    vec3 topTint = tempColor * 1.45;
+    vec3 gradientColor = mix(bottomTint, topTint, smoothstep(0.0, 1.0, vTempRatio));
+
+    // Heat-shimmer bands: rising horizontal stripes, stronger for hot days
+    float heat = smoothstep(0.0, 2.0, uZScore);
+    float bands = sin((vTempRatio * 18.0) - uTime * 2.0);
+    bands = smoothstep(0.6, 1.0, bands) * 0.25 * heat;
+    gradientColor += tempColor * bands;
+
+    // Frost crystalline shimmer for cold days
+    float cold = smoothstep(0.0, 2.0, -uZScore);
+    float frost = sin(vTempRatio * 40.0 + uTime * 1.5) * sin(vUv.x * 50.0);
+    frost = smoothstep(0.7, 1.0, frost) * 0.35 * cold;
+    gradientColor += vec3(0.8, 0.95, 1.0) * frost;
+
+    // Wind-driven diagonal streaks across the column
+    float windStreak = sin((vUv.x * 8.0) + (vTempRatio * 4.0) - uTime * (2.0 + uWindStrength * 6.0));
+    windStreak = smoothstep(0.75, 1.0, windStreak) * 0.4 * uWindStrength;
+    gradientColor += mix(vec3(0.8, 0.9, 1.0), tempColor, 0.5) * windStreak;
+
+    // Slow breathing pulse — stronger for today
+    float pulse = 1.0 + sin(uTime * 2.0) * 0.08 * uGlowIntensity;
     gradientColor *= pulse;
-    
-    // Edge highlight for 3D definition
+
+    // Rim/fresnel glow for glassy 3D definition
     vec3 viewDir = normalize(cameraPosition - vWorldPosition);
     vec3 normal = normalize(cross(dFdx(vWorldPosition), dFdy(vWorldPosition)));
-    float fresnel = pow(1.0 - abs(dot(viewDir, normal)), 2.0);
-    gradientColor += tempColor * fresnel * 0.3;
-    
-    gl_FragColor = vec4(gradientColor, 0.9);
+    float fresnel = pow(1.0 - abs(dot(viewDir, normal)), 2.5);
+    gradientColor += tempColor * fresnel * (0.6 + uGlowIntensity * 0.4);
+
+    // Top-cap brightening
+    float cap = smoothstep(0.85, 1.0, vTempRatio);
+    gradientColor += tempColor * cap * 0.4;
+
+    float alpha = 0.85 + fresnel * 0.15;
+    gl_FragColor = vec4(gradientColor, alpha);
   }
 `;
 
@@ -571,9 +594,25 @@ export class DayColumn {
   init() {
     this.createMesh();
     this.createWeatherParticles();
+    this.createThermalAura();
+    this.createWindStreaks();
+    this.createLabel();
     if (this.data.type === 'historical' && this.data.accuracy) {
       this.createAccuracyRing();
     }
+  }
+
+  computeAvgWind() {
+    const hours = this.data.hourly;
+    if (!Array.isArray(hours) || hours.length === 0) return 0;
+    let total = 0, count = 0;
+    for (const h of hours) {
+      if (typeof h.windSpeed === 'number') {
+        total += h.windSpeed;
+        count++;
+      }
+    }
+    return count > 0 ? total / count : 0;
   }
   
   createMesh() {
@@ -586,6 +625,11 @@ export class DayColumn {
     const isToday = this.data.type === 'forecast' && Math.abs(this.data.dayOffset || 0) < 0.5;
     const glowIntensity = isToday ? 1.0 : 0.5;
     
+    // Normalize wind: 40 km/h ≈ full strength
+    const avgWind = this.computeAvgWind();
+    this.avgWindSpeed = avgWind;
+    const windStrength = Math.min(1, avgWind / 40);
+
     const material = new THREE.ShaderMaterial({
       uniforms: {
         uZScore: { value: this.data.zScore || 0 },
@@ -593,6 +637,7 @@ export class DayColumn {
         uTempMax: { value: this.data.tempMax || 0 },
         uTime: { value: 0 },
         uGlowIntensity: { value: glowIntensity },
+        uWindStrength: { value: windStrength },
         uColorCold: { value: TEMP_COLORS.cold },
         uColorCool: { value: TEMP_COLORS.cool },
         uColorNeutral: { value: TEMP_COLORS.neutral },
@@ -625,6 +670,175 @@ export class DayColumn {
     );
   }
   
+  createThermalAura() {
+    const z = this.data.zScore || 0;
+    if (Math.abs(z) < 0.8) return; // Only for notably hot/cold days
+
+    const isHot = z > 0;
+    const intensity = Math.min(1, (Math.abs(z) - 0.8) / 1.5);
+    const color = isHot ? new THREE.Color(0xff6b35) : new THREE.Color(0x8fd9ff);
+
+    // Soft glowing halo cylinder around the column
+    const { height, radius } = this.options;
+    const auraGeo = new THREE.CylinderGeometry(
+      radius * 1.25,
+      radius * 1.4,
+      height * 1.05,
+      24,
+      1,
+      true
+    );
+    const auraMat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: { value: 0 },
+        uColor: { value: color },
+        uIntensity: { value: intensity },
+        uIsHot: { value: isHot ? 1.0 : 0.0 }
+      },
+      vertexShader: `
+        varying vec2 vUv;
+        varying vec3 vWorldPosition;
+        void main() {
+          vUv = uv;
+          vec4 wp = modelMatrix * vec4(position, 1.0);
+          vWorldPosition = wp.xyz;
+          gl_Position = projectionMatrix * viewMatrix * wp;
+        }
+      `,
+      fragmentShader: `
+        uniform float uTime;
+        uniform vec3 uColor;
+        uniform float uIntensity;
+        uniform float uIsHot;
+        varying vec2 vUv;
+        varying vec3 vWorldPosition;
+        void main() {
+          // Hot: shimmer rising upward; Cold: drifting downward
+          float dir = mix(-1.0, 1.0, uIsHot);
+          float ripple = sin((vUv.y * 8.0) - uTime * dir * 1.5 + vUv.x * 6.2831) * 0.5 + 0.5;
+          float vert = mix(0.55, 0.0, vUv.y); // fade toward top
+          float side = 1.0 - abs(vUv.x * 2.0 - 1.0);
+          float a = ripple * vert * side * uIntensity * 0.9;
+          gl_FragColor = vec4(uColor, a);
+        }
+      `,
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending
+    });
+    this.auraMesh = new THREE.Mesh(auraGeo, auraMat);
+    this.auraMesh.position.y = 0;
+    this.mesh.add(this.auraMesh);
+  }
+
+  createWindStreaks() {
+    const wind = this.avgWindSpeed || 0;
+    if (wind < 10) return; // Only for breezy days and up
+
+    const strength = Math.min(1, wind / 40);
+    const count = Math.floor(8 + strength * 24);
+    const { radius, height } = this.options;
+
+    const geometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(count * 6);
+    const phases = new Float32Array(count * 2);
+
+    for (let i = 0; i < count; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const r = radius * (1.05 + Math.random() * 0.25);
+      const y = (Math.random() - 0.5) * height * 0.9;
+      const x = Math.cos(angle) * r;
+      const z = Math.sin(angle) * r;
+      const len = 0.25 + Math.random() * 0.5;
+      const tx = -Math.sin(angle) * len;
+      const tz = Math.cos(angle) * len;
+
+      positions[i * 6] = x;
+      positions[i * 6 + 1] = y;
+      positions[i * 6 + 2] = z;
+      positions[i * 6 + 3] = x + tx;
+      positions[i * 6 + 4] = y;
+      positions[i * 6 + 5] = z + tz;
+      phases[i * 2] = angle;
+      phases[i * 2 + 1] = y;
+    }
+
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+    const material = new THREE.LineBasicMaterial({
+      color: 0xcfe9ff,
+      transparent: true,
+      opacity: 0.35 + strength * 0.4,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false
+    });
+
+    this.windMesh = new THREE.LineSegments(geometry, material);
+    this.windMesh.userData.basePhases = phases;
+    this.windMesh.userData.windStrength = strength;
+    this.mesh.add(this.windMesh);
+  }
+
+  createLabel() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 128;
+    const ctx = canvas.getContext('2d');
+
+    const date = new Date(this.data.date + 'T00:00:00');
+    const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
+    const monthDay = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const hi = this.data.tempMax != null ? `${Math.round(this.data.tempMax)}°` : '--';
+    const lo = this.data.tempMin != null ? `${Math.round(this.data.tempMin)}°` : '--';
+
+    ctx.fillStyle = 'rgba(8, 12, 20, 0.55)';
+    ctx.beginPath();
+    const r = 18;
+    const w = canvas.width, h = canvas.height;
+    ctx.moveTo(r, 0);
+    ctx.lineTo(w - r, 0);
+    ctx.quadraticCurveTo(w, 0, w, r);
+    ctx.lineTo(w, h - r);
+    ctx.quadraticCurveTo(w, h, w - r, h);
+    ctx.lineTo(r, h);
+    ctx.quadraticCurveTo(0, h, 0, h - r);
+    ctx.lineTo(0, r);
+    ctx.quadraticCurveTo(0, 0, r, 0);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 36px Inter, system-ui, sans-serif';
+    ctx.fillText(dayName, w / 2, 30);
+    ctx.font = '20px Inter, system-ui, sans-serif';
+    ctx.fillStyle = 'rgba(255,255,255,0.75)';
+    ctx.fillText(monthDay, w / 2, 60);
+
+    ctx.font = 'bold 30px Inter, system-ui, sans-serif';
+    ctx.fillStyle = '#ffb74d';
+    ctx.fillText(hi, w / 2 - 38, 100);
+    ctx.fillStyle = '#8fd9ff';
+    ctx.fillText(lo, w / 2 + 38, 100);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.minFilter = THREE.LinearFilter;
+    texture.needsUpdate = true;
+
+    const material = new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthWrite: false
+    });
+
+    this.labelSprite = new THREE.Sprite(material);
+    this.labelSprite.scale.set(2.2, 1.1, 1);
+    this.labelSprite.position.y = this.options.height / 2 + 1.2;
+    this.mesh.add(this.labelSprite);
+  }
+
   createAccuracyRing() {
     if (!this.data.accuracy) return;
     
@@ -683,6 +897,10 @@ export class DayColumn {
         material.uniforms.uGlowIntensity.value = 0.1;
         break;
     }
+
+    if (this.auraMesh) this.auraMesh.visible = newLOD !== 'low';
+    if (this.windMesh) this.windMesh.visible = newLOD !== 'low';
+    if (this.labelSprite) this.labelSprite.visible = newLOD !== 'low';
   }
   
   /**
@@ -700,6 +918,19 @@ export class DayColumn {
     // Update particle system
     if (this.particleSystem && this.lodLevel !== 'low') {
       this.particleSystem.update(delta, this.time);
+    }
+
+    // Thermal aura shimmer
+    if (this.auraMesh && this.auraMesh.material.uniforms) {
+      this.auraMesh.material.uniforms.uTime.value = this.time;
+    }
+
+    // Wind streak drift — rotate streaks around column
+    if (this.windMesh && this.lodLevel !== 'low') {
+      const strength = this.windMesh.userData.windStrength || 0.3;
+      this.windMesh.rotation.y += delta * (0.4 + strength * 1.8);
+      this.windMesh.material.opacity =
+        (0.35 + strength * 0.4) * (0.85 + Math.sin(this.time * 3) * 0.15);
     }
   }
   
@@ -889,6 +1120,29 @@ export class DayColumn {
     if (this.accuracyRing) {
       this.accuracyRing.dispose();
       this.accuracyRing = null;
+    }
+
+    // Dispose aura
+    if (this.auraMesh) {
+      this.auraMesh.geometry.dispose();
+      this.auraMesh.material.dispose();
+      this.auraMesh = null;
+    }
+
+    // Dispose wind streaks
+    if (this.windMesh) {
+      this.windMesh.geometry.dispose();
+      this.windMesh.material.dispose();
+      this.windMesh = null;
+    }
+
+    // Dispose label sprite
+    if (this.labelSprite) {
+      if (this.labelSprite.material) {
+        if (this.labelSprite.material.map) this.labelSprite.material.map.dispose();
+        this.labelSprite.material.dispose();
+      }
+      this.labelSprite = null;
     }
     
     // Dispose mesh and material


### PR DESCRIPTION
## Summary
Each day in the 3D 10-day timeline now visually expresses its weather character.

### Per-day visual additions (`src/timeline/DayColumn.js`)
- **Heat shimmer bands** — animated rising stripes on hot days (`zScore > 0`)
- **Frost crystalline sparkle** — icy speckle pattern on cold days (`zScore < 0`)
- **Wind streaks** — diagonal moving streaks across the column, driven by avg daily wind speed (new `uWindStrength` shader uniform)
- **Thermal aura halo** — soft additive cylinder around the column, warm orange for extreme heat (`|z| > 0.8`, hot) or icy blue (cold), with directional ripple
- **Orbiting wind line-streaks** — short tangent line segments orbiting the column when avg wind ≥ 10 km/h, density and opacity scale with strength
- **Floating day label sprite** — glassmorphism Canvas-textured sprite above each column with weekday, date, and high/low temps
- **Glassier shader** — stronger fresnel rim glow, top-cap brightening, gentle breathing pulse

### Cleanup
- `computeAvgWind()` helper aggregates hourly wind into a per-day average
- LOD switching hides aura / wind / label at far distance
- `dispose()` cleans up all new geometries, materials, and the label texture

## Test plan
- [ ] Load the app, open the 10-day timeline view
- [ ] Verify hot days show orange aura + heat bands, cold days show blue aura + frost speckle
- [ ] Verify windy days show orbiting streaks; calm days show none
- [ ] Verify each column has a floating label with weekday/date and hi/lo temps
- [ ] Switch between timeline and main view to confirm no leaks/console errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01HN45F5whKMydWdHvi5Rbzp)_