### PR TITLE
fix: remove hardcoded deployment token (closes #68)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DEPLOY_TOKEN=replace_with_your_deploy_token

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 .vite
 .cache
 package-lock.json
+.env
+.env.*
+!.env.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ The app has two viewing modes:
 ### Root
 - `index.html` — Entry point. Loads Three.js via an import map and mounts `src/main.js`.
 - `package.json` — NPM manifest with Vite/Vitest scripts.
-- `deploy.py` — **Security note:** Paramiko SFTP deployment script containing hardcoded server credentials.
+- `deploy.py` — Deployment bundle uploader. Requires `DEPLOY_TOKEN` from the environment for uploads.
 
 ### Source (`src/`)
 | File | Responsibility |
@@ -162,7 +162,7 @@ Screenshots are saved into `verification/` for manual comparison.
 
 ## Security Considerations
 
-- **`deploy.py` contains hardcoded SFTP credentials.** Do not run this script blindly, and do not commit modified versions that expose secrets.
+- **Deployment credentials must stay out of source.** Set `DEPLOY_TOKEN` in the environment before running `deploy.py`, and do not commit `.env` files or real tokens.
 - The app fetches data from external APIs (Open-Meteo, Nominatim) over HTTPS. No API keys are required.
 - User location and unit preferences are stored in `localStorage` under the keys:
   - `weatherclock_lat`

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ The goal: make time *visible* and *tactile*—a living, breathing environment in
    ```
    Output lands in `dist/` folder—ready to deploy.
 
+4. **Deploy:**
+   ```bash
+   export DEPLOY_TOKEN="your_deploy_token"
+   python3 deploy.py
+   ```
+   Copy `.env.example` to `.env` if you prefer local environment files, then source it before deploying:
+   ```bash
+   set -a
+   source .env
+   set +a
+   ```
+   Keep real tokens out of git. To verify the deployment zip without uploading, run:
+   ```bash
+   python3 deploy.py --dry-run
+   ```
+
 ### For Developers
 
 See **[claude.md](./claude.md)** for:

--- a/claude.md
+++ b/claude.md
@@ -140,6 +140,15 @@ npm run preview
 
 Output is in `dist/` folder - ready for deployment to any static host.
 
+For the bundled deploy script, set the token through the environment before uploading:
+
+```bash
+export DEPLOY_TOKEN="your_deploy_token"
+python3 deploy.py
+```
+
+Use `python3 deploy.py --dry-run` to build the zip without uploading or requiring a token. Do not commit `.env` files or real deploy tokens.
+
 ## Dependencies
 
 - **Three.js** ^0.181.2 - 3D rendering

--- a/deploy.py
+++ b/deploy.py
@@ -20,14 +20,13 @@ Requirements:
   pip install requests
 """
 
+import argparse
 import io
 import os
 import sys
 import zipfile
 from pathlib import Path
 from typing import Optional
-
-import requests
 
 # ============================================================
 # PER-PROJECT CONFIGURATION - EDIT THESE
@@ -37,9 +36,9 @@ BUILD_DIR: str = 'dist'
 CONTABO_BASE_URL: str = "https://storage.noahcohn.com"
 DEPLOY_FOLDER: str = ""  # override remote target folder; empty = use PROJECT_NAME
 
-# Optional deploy token (recommended for security).
+# Required deploy token for uploads.
 # Set via environment: export DEPLOY_TOKEN="your_long_token_from_vps_env"
-DEPLOY_TOKEN: Optional[str] = "6de44dca5425348f2e2ef9456fc820bfe56a5ace68bddeb6da4a1c2a9d9cadc0"
+DEPLOY_TOKEN: Optional[str] = os.environ.get("DEPLOY_TOKEN")
 # ============================================================
 
 
@@ -60,17 +59,23 @@ def build_zip(build_path: Path) -> bytes:
     return buf.getvalue()
 
 
-def deploy_bundle(build_path: Path) -> bool:
-    """Zip the build and upload it as a single bundle."""
-    target_folder = DEPLOY_FOLDER or PROJECT_NAME
-    url = f"{CONTABO_BASE_URL}/api/deploy/{PROJECT_NAME}/bundle"
-    headers = {}
-    if DEPLOY_TOKEN:
-        headers["X-Deploy-Token"] = DEPLOY_TOKEN
-
+def prepare_bundle(build_path: Path) -> bytes:
+    """Zip the build directory and print archive metadata."""
     print("Building zip archive...")
     zip_bytes = build_zip(build_path)
     print(f"Archive size: {len(zip_bytes) / 1024:.1f} KB\n")
+    return zip_bytes
+
+
+def deploy_bundle(build_path: Path, deploy_token: str) -> bool:
+    """Zip the build and upload it as a single bundle."""
+    import requests
+
+    target_folder = DEPLOY_FOLDER or PROJECT_NAME
+    url = f"{CONTABO_BASE_URL}/api/deploy/{PROJECT_NAME}/bundle"
+    headers = {"X-Deploy-Token": deploy_token}
+
+    zip_bytes = prepare_bundle(build_path)
 
     print("Uploading bundle...")
     try:
@@ -98,14 +103,40 @@ def deploy_bundle(build_path: Path) -> bool:
         return False
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Upload the production build as a bundle to the Contabo deploy service.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the deployment zip only; do not upload or require DEPLOY_TOKEN.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
     print(f"\n=== Deploying '{PROJECT_NAME}' via Contabo -> storage.1ink.us ===\n")
+
+    if not args.dry_run and not DEPLOY_TOKEN:
+        print("ERROR: DEPLOY_TOKEN is required for deployment.")
+        print('Set it in your environment, for example: export DEPLOY_TOKEN="your_deploy_token"')
+        print("Use --dry-run to build the zip archive without uploading.")
+        sys.exit(1)
 
     build_path = Path(BUILD_DIR)
     if not build_path.exists() or not build_path.is_dir():
         print(f"ERROR: Build directory '{BUILD_DIR}/' does not exist.")
         print("Please run your build command first (e.g. `npm run build`).")
         sys.exit(1)
+
+    if args.dry_run:
+        prepare_bundle(build_path)
+        print("Dry run complete. No upload attempted.")
+        sys.exit(0)
+
+    import requests
 
     try:
         health = requests.get(f"{CONTABO_BASE_URL}/api/deploy/health", timeout=10)
@@ -115,7 +146,7 @@ def main():
         print("Warning: Could not contact storage.noahcohn.com (continuing anyway).")
 
     print()
-    success = deploy_bundle(build_path)
+    success = deploy_bundle(build_path, DEPLOY_TOKEN)
 
     print(f"\n=== {'Deployment complete' if success else 'Deployment finished with errors'} ===")
     sys.exit(0 if success else 1)

--- a/grok.md
+++ b/grok.md
@@ -107,7 +107,7 @@ npm run build
 npm run preview
 ```
 
-Output in `dist/`. Note: `deploy.py` has hardcoded credentials — use cautiously.
+Output in `dist/`. Set `DEPLOY_TOKEN` in the environment before running `python3 deploy.py`, or use `python3 deploy.py --dry-run` to build the zip without uploading.
 
 ## Code Style & Best Practices
 


### PR DESCRIPTION
# Remove hardcoded deploy token

## Summary

- Removed the committed deploy token from `deploy.py`.
- Changed `DEPLOY_TOKEN` to read from `os.environ.get("DEPLOY_TOKEN")`.
- Added a clear startup error when `DEPLOY_TOKEN` is missing for real deployments.
- Added `--dry-run` so maintainers can build and inspect the deployment zip without a token or upload.
- Added `.env.example` with a placeholder token name.
- Updated `.gitignore` to ignore real `.env` files while keeping `.env.example`.
- Documented deploy setup in `README.md`, `claude.md`, `grok.md`, and `AGENTS.md`.
- Documented that local `.env` files must be sourced before running the deploy script.

## Maintainer Action Required

The previously committed deploy token should be invalidated on the server side immediately. Generate a new deploy token and provide it only through a private environment variable or local `.env` file that is not committed to the repository.

## Verification

Run these checks before merging:

```bash
npm run build
python3 deploy.py --dry-run
unset DEPLOY_TOKEN
python3 deploy.py
```

Expected behavior:

- `python3 deploy.py --dry-run` builds the zip and does not upload.
- `python3 deploy.py` exits with a clear `DEPLOY_TOKEN is required` error when the token is missing.
- A real deployment works only after setting `DEPLOY_TOKEN` in the environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` mode for testing deployments without uploads.

* **Documentation**
  * Updated deployment guides with new `DEPLOY_TOKEN` environment variable setup.
  * Added instructions for environment file configuration and token management.

* **Configuration**
  * Improved deployment security by using environment variables instead of hardcoded tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->