### PR TITLE
Fix WebGPU post-processing crash and production chunk 404s

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,15 +230,6 @@
     <div id="dev-hint">` — toggle stats</div>
     <div id="toast-container"></div>
 
-    <script type="importmap">
-        {
-            "imports": {
-                "three": "/node_modules/three/build/three.module.js",
-                "three/addons/": "/node_modules/three/examples/jsm/",
-                "suncalc": "/src/vendor/suncalc.js"
-            }
-        }
-    </script>
     <script type="module" src="/src/main.js"></script>
     <script>
         // Minimal delegation for mode-toggle since ModeController skips attaching when element already exists

--- a/src/webgpu/PostProcessingPipeline.js
+++ b/src/webgpu/PostProcessingPipeline.js
@@ -51,20 +51,35 @@ export async function createPostProcessingPipeline(
     }
 
     if (isWebGPU) {
-        const { PostProcessing } = await import('three/webgpu');
-        const { pass, bloom, toneMapping } = await import('three/tsl');
+        try {
+            const { PostProcessing } = await import('three/webgpu');
+            const { pass } = await import('three/tsl');
+            const { bloom } = await import('three/addons/tsl/display/BloomNode.js');
 
-        const pp = new PostProcessing(renderer);
-        const bloomNode = bloom(pass(scene, camera), { strength, radius, threshold });
-        pp.outputNode = toneMapping(bloomNode, THREE.ACESFilmicToneMapping, 1.0);
+            const pp = new PostProcessing(renderer);
+            const scenePass = pass(scene, camera);
+            const scenePassColor = scenePass.getTextureNode('output');
+            const bloomPass = bloom(scenePassColor, strength, radius, threshold);
+            pp.outputNode = scenePassColor.add(bloomPass);
 
-        return {
-            render: () => pp.render(),
-            setSize: (w, h) => pp.setSize(w, h),
-            dispose: () => {
-                pp.dispose();
-            }
-        };
+            return {
+                render: () => pp.render(),
+                setSize: (w, h) => {
+                    renderer.setSize(w, h);
+                    pp.needsUpdate = true;
+                },
+                dispose: () => {
+                    pp.dispose();
+                }
+            };
+        } catch (err) {
+            console.warn('[PostProcessingPipeline] WebGPU bloom setup failed, using direct render:', err);
+            return {
+                render: () => renderer.render(scene, camera),
+                setSize: (w, h) => renderer.setSize(w, h),
+                dispose: () => {}
+            };
+        }
     }
 
     // WebGL path — EffectComposer + UnrealBloomPass

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks(id) {
+                    if (id.includes('three/build/three.webgpu')) {
+                        return 'three.webgpu';
+                    }
+                    if (id.includes('three/build/three.tsl')) {
+                        return 'three.tsl';
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the production crash when WebGPU is selected as the renderer:

```
Uncaught (in promise) TypeError: g is not a function
Failed to load resource: three.tsl-*.js (404)
Failed to load resource: three.webgpu-*.js (404)
```

## Root causes

1. **Wrong `bloom` import** — `bloom` was imported from `three/tsl`, but in Three.js r181 it lives in `three/addons/tsl/display/BloomNode.js`. The missing export made `bloom` `undefined`, causing the `g is not a function` error in minified code.

2. **Incorrect TSL post-processing API** — The pipeline passed an options object to `bloom()` and manually called `toneMapping()` with reversed arguments. The correct pattern per Three.js docs is:
   - `scenePass.getTextureNode('output')`
   - `bloom(scenePassColor, strength, radius, threshold)`
   - `scenePassColor.add(bloomPass)` with `PostProcessing.outputColorTransform` left at its default (handles tone mapping automatically)

3. **Invalid `pp.setSize()` call** — `PostProcessing` has no `setSize` method; resize now calls `renderer.setSize()` and marks the pipeline dirty.

4. **Dev import map shipped to production** — `index.html` contained an import map pointing at `/node_modules/...` paths that do not exist in `dist/`, which could interfere with module resolution after deploy.

## Changes

- `src/webgpu/PostProcessingPipeline.js` — correct bloom import, TSL API usage, resize handling, and try/catch fallback to direct render
- `index.html` — remove dev-only import map (Vite resolves `three` from `node_modules` in both dev and build)
- `vite.config.js` — explicit chunk splitting for WebGPU modules

## Testing

- `npm run build` — succeeds, all asset chunks emitted under `dist/assets/`
- `npm test -- --run` — 27/27 tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a59f411-c21d-4ff0-9eea-6bbdf4eb2f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a59f411-c21d-4ff0-9eea-6bbdf4eb2f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

