### PR TITLE
Default deploy base URL and improve setup hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ The goal: make time *visible* and *tactile*—a living, breathing environment in
    ```
    Output lands in `dist/` folder—ready to deploy.
 
+4. **Deploy to the project host (optional):**
+   ```bash
+   cp deploy.config.example.json deploy.config.json
+   # Edit deploy.config.json and set your deploy token (never commit this file)
+   npm run build
+   python3 deploy.py
+   ```
+   `deploy.py` defaults to `https://storage.noahcohn.com` for this project. You can override
+   settings with environment variables such as `DEPLOY_TOKEN` and `DEPLOY_BASE_URL`.
+
 ### For Developers
 
 See **[AGENTS.md](./AGENTS.md)** for:

--- a/deploy.config.example.json
+++ b/deploy.config.example.json
@@ -1,5 +1,5 @@
 {
-    "base_url": "https://deploy.example.com",
+    "base_url": "https://storage.noahcohn.com",
     "token": "replace-with-a-newly-rotated-token",
     "project_name": "weather-clock",
     "build_dir": "dist",

--- a/deploy.py
+++ b/deploy.py
@@ -18,6 +18,11 @@ import requests
 
 
 CONFIG_PATH = Path(os.environ.get("DEPLOY_CONFIG", "deploy.config.json"))
+DEFAULT_BASE_URL = "https://storage.noahcohn.com"
+SETUP_HINT = (
+    f"Copy deploy.config.example.json to {CONFIG_PATH.name}, set your deploy token, "
+    "or export DEPLOY_TOKEN (and optionally DEPLOY_BASE_URL)."
+)
 
 
 def load_config(path: Path = CONFIG_PATH) -> dict[str, Any]:
@@ -41,12 +46,21 @@ def setting(config: dict[str, Any], env_name: str, config_name: str, default: st
     return str(value).strip() if value is not None else ""
 
 
-def required_setting(config: dict[str, Any], env_name: str, config_name: str) -> str:
+def required_setting(
+    config: dict[str, Any],
+    env_name: str,
+    config_name: str,
+    *,
+    hint: str = "",
+) -> str:
     value = setting(config, env_name, config_name)
     if not value:
-        raise RuntimeError(
+        message = (
             f"Missing deployment setting: set {env_name} or '{config_name}' in {CONFIG_PATH}"
         )
+        if hint:
+            message = f"{message}\n{hint}"
+        raise RuntimeError(message)
     return value
 
 
@@ -109,8 +123,8 @@ def deploy_bundle(
 def main() -> None:
     try:
         config = load_config()
-        base_url = required_setting(config, "DEPLOY_BASE_URL", "base_url")
-        deploy_token = required_setting(config, "DEPLOY_TOKEN", "token")
+        base_url = setting(config, "DEPLOY_BASE_URL", "base_url", DEFAULT_BASE_URL)
+        deploy_token = required_setting(config, "DEPLOY_TOKEN", "token", hint=SETUP_HINT)
         project_name = setting(config, "DEPLOY_PROJECT_NAME", "project_name", "weather-clock")
         build_dir = setting(config, "DEPLOY_BUILD_DIR", "build_dir", "dist")
         target_folder = setting(config, "DEPLOY_FOLDER", "target_folder", project_name)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `Missing deployment setting: set DEPLOY_BASE_URL or 'base_url' in deploy.config.json` error when running `python3 deploy.py` without local deployment config.

After the security refactor in #68, both `base_url` and `token` became required with no defaults. The deployment host (`https://storage.noahcohn.com`) is not a secret—it was previously hardcoded in `deploy.py`—so this change restores it as the default while keeping the deploy token required.

## Changes

- Default `DEPLOY_BASE_URL` / `base_url` to `https://storage.noahcohn.com`
- Improve the missing-token error with a setup hint pointing to `deploy.config.example.json`
- Update `deploy.config.example.json` and `README.md` with deployment setup steps

## How to deploy locally

```bash
cp deploy.config.example.json deploy.config.json
# Edit deploy.config.json and set your deploy token
npm run build
python3 deploy.py
```

Or export `DEPLOY_TOKEN` without creating a config file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eca0ee0c-d335-4b02-aea6-c9b5c2ac78fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eca0ee0c-d335-4b02-aea6-c9b5c2ac78fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

