### PR TITLE
Fix Cloud preview showing code-server instead of weather clock

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+    "name": "weather_clock",
+    "install": "npm install",
+    "ports": [
+        {
+            "name": "Weather Clock",
+            "port": 5173
+        }
+    ],
+    "terminals": [
+        {
+            "name": "Dev Server",
+            "command": "npm run dev",
+            "description": "Vite dev server for the 3D weather clock app"
+        }
+    ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Lighting is a weighted blend of all three zones: Past (20%), Current (50%), Fore
 
 ## Cursor Cloud specific instructions
 
-Node dependencies are refreshed automatically on startup (`npm install`), so the standard commands in **Build and Test Commands** (`npm run dev`, `npm test`, `npm run lint`, `npm run build`) work out of the box. `npm run dev` serves the app on `http://localhost:5173`; start it in a background/`tmux` session since it is long-running.
+Node dependencies are refreshed automatically on startup (`npm install`), so the standard commands in **Build and Test Commands** (`npm run dev`, `npm test`, `npm run lint`, `npm run build`) work out of the box. `npm run dev` serves the app on `http://localhost:5173`; the repo's `.cursor/environment.json` auto-starts it and exposes port **5173** (not the noVNC desktop on 26058). Vite is configured with `server.host: true` so IPv4 port forwarding works.
 
 - **Full CI parity locally:** the CI pipeline runs `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test -- --run`, `npm run build`, and `npm run check:bundle-size`. Run these before committing to match CI.
 - **Weather test noise is expected:** `npm test` prints `stderr` warnings about failed/offline fetches for the caching-fallback tests — these are mocked failures, and the suite still passes.

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,6 +45,16 @@ function manualChunks(id) {
 }
 
 export default defineConfig({
+    server: {
+        // Bind IPv4 as well as IPv6 so Cursor Cloud port forwarding (127.0.0.1)
+        // and CI smoke tests can reach the dev server.
+        host: true,
+        port: 5173
+    },
+    preview: {
+        host: true,
+        port: 4173
+    },
     build: {
         target: 'esnext',
         // The UI icons are tiny SVGs; keep the limit explicit so they stay


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Cursor Cloud, opening the weather clock preview showed the noVNC/code-server desktop instead of the app.

## Root cause

1. **Vite bound to IPv6 only** (`::1:5173`). Cursor Cloud port forwarding connects via `127.0.0.1` (IPv4), so the forwarded port was unreachable and the UI fell back to the desktop display (noVNC on port 26058).
2. **No repo-level environment config** to auto-start the dev server and advertise port 5173.

## Fix

- Set `server.host: true` (and matching `preview.host`) in `vite.config.js` so the dev server listens on all interfaces.
- Add `.cursor/environment.json` to run `npm run dev` on startup and expose port **5173** as "Weather Clock".
- Document the correct port in `AGENTS.md`.

## Verification

- `curl http://127.0.0.1:5173/` returns 200 after the change.
- `python3 verification/suite/run_all.py --smoke-only` passes.

## What you should do

After merging, either:
- Start a new cloud agent from this branch/main (repo `.cursor/environment.json` takes priority over saved personal environments), or
- In the Cloud Agents dashboard, update your saved `ford442/weather_clock` environment to expose port **5173** instead of the noVNC display port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5140855c-18f1-4977-aef5-39ea826be688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5140855c-18f1-4977-aef5-39ea826be688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

